### PR TITLE
fix: downgrade HNSW index failure log to WARNING

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -1171,7 +1171,7 @@ class PostgreSQLDB:
                         f"HNSW vector index {vector_index_name} already exists on table {k}"
                     )
             except Exception as e:
-                logger.error(f"Failed to create vector index on table {k}, Got: {e}")
+                logger.warning(f"Failed to create vector index on table {k}, Got: {e}")
 
     async def _create_ivfflat_vector_indexes(self):
         vdb_tables = [


### PR DESCRIPTION
## Summary
- Downgrade `logger.error` → `logger.warning` in `_create_hnsw_vector_indexes()` when HNSW index creation fails (e.g. >2000 dimensions)
- LightRAG still functions without the index (sequential scan fallback), so this is a non-blocking degradation, not a critical error

## Test plan
- [ ] Deploy with `EMBEDDING_DIM` > 2000 and verify the log is WARNING, not ERROR
- [ ] Verify LightRAG queries still work without the HNSW index

🤖 Generated with [Claude Code](https://claude.com/claude-code)