### PR TITLE
Reapply fork-specific keeps (CI, content dedup, docker-compose)

### DIFF
--- a/.github/workflows/azure-prod-build-push.yaml
+++ b/.github/workflows/azure-prod-build-push.yaml
@@ -1,0 +1,59 @@
+name: prod-azure-lightrag-build-push-pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  AZURE_REGION: eastus
+  AZURE_CONTAINER_REGISTRY: applicationmodernizationprodacr.azurecr.io
+  AZURE_REPOSITORY_NAME: 3-light-rag
+  AZURE_RESOURCE_GROUP: application-modernization-prod-rg
+  AZURE_SERVICE_PRINCIPAL_ID: ${{ secrets.AZURE_SERVICE_PRINCIPAL_ID }}
+  AZURE_SERVICE_PRINCIPAL_PASSWORD: ${{ secrets.AZURE_SERVICE_PRINCIPAL_PASSWORD }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main repository
+        uses: actions/checkout@v4
+
+      # - name: Setup SSH for submodules
+      #   uses: webfactory/ssh-agent@v0.9.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      # - name: Checkout LightRAG submodule
+      #   run: |
+      #     git submodule update --init --recursive 4-LightRAG
+
+      - name: Log in to Azure CLI
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Azure Container Registry Login
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ env.AZURE_CONTAINER_REGISTRY }}
+          username: ${{ env.AZURE_SERVICE_PRINCIPAL_ID }}
+          password: ${{ env.AZURE_SERVICE_PRINCIPAL_PASSWORD }}
+
+      - name: Docker Build and Publish
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.AZURE_CONTAINER_REGISTRY }}/${{ env.AZURE_REPOSITORY_NAME }}:${{ github.run_number }}
+          

--- a/.github/workflows/lab-deploy-build-push.yaml
+++ b/.github/workflows/lab-deploy-build-push.yaml
@@ -1,0 +1,45 @@
+# This pipeline will run that builds and deploys the docker container any time a PR is Raised and Merged against "main" Branch to Innovation LAB Environment
+name: innovation-lab-build-push
+on:
+  push:
+    branches:
+      - develop
+      # - ci-pipeline
+      # - ' '
+  workflow_dispatch:
+
+# Used for getting permissions to AWS resources through an OIDC federation
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ca-central-1
+  AWS_ACCOUNT_ID: 211125670787
+  ECR_REPO: lightrag
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Configure AWS credentials'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/innovation-lab-github-oidc-3
+          role-session-name: githubAWSSession
+          role-duration-seconds: 3600
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/checkout@v2
+      - name: Login to ECR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO }} ##image
+
+      - name: Docker Build and Publish
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO }}:${{github.run_number}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   lightrag:
-    image: ghcr.io/hkuds/lightrag:latest
+    # image: ghcr.io/hkuds/lightrag:latest  # Commented out to use local code
     build:
       context: .
       dockerfile: Dockerfile
@@ -24,3 +24,9 @@ services:
       INPUT_DIR: "/app/data/inputs"
       HOST: "0.0.0.0"
       PORT: "9621"
+    networks:
+      poc_network:
+
+networks:
+  poc_network:
+    external: true

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1415,19 +1415,25 @@ class LightRAG:
             }
         else:
             # Clean input text and remove duplicates in one pass
-            unique_content_with_paths = {}
+            # Note: We keep all files even if content is the same, as different files should have different IDs
+            unique_content_with_paths = []
+            seen = set()
             for doc, path in zip(input, file_paths):
                 cleaned_content = sanitize_text_for_encoding(doc)
-                if cleaned_content not in unique_content_with_paths:
-                    unique_content_with_paths[cleaned_content] = path
+                # Use (content, path) as key to allow same content from different files
+                key = (cleaned_content, path)
+                if key not in seen:
+                    seen.add(key)
+                    unique_content_with_paths.append((cleaned_content, path))
 
             # Generate contents dict of MD5 hash IDs and documents with paths
+            # Include file path in ID generation to ensure different files get different IDs
             contents = {
-                compute_mdhash_id(content, prefix="doc-"): {
+                compute_mdhash_id(f"{content}\0{path}", prefix="doc-"): {
                     "content": content,
                     "file_path": path,
                 }
-                for content, path in unique_content_with_paths.items()
+                for content, path in unique_content_with_paths
             }
 
         # 2. Generate document initial status (without content)


### PR DESCRIPTION
## Summary

Reapplies the small set of fork-specific changes that survived audit after the upstream resync (PR #10). Just CI workflows + a content-dedup behavior choice + docker-compose tweaks for local dev. **~125 lines, three commits.**

## Stacked on top of #10

This PR targets `sync/upstream-main` for now so the diff only shows the reapply (the upstream sync is reviewed separately in #10). **Retarget to `develop` once #10 merges** — the changes will then apply cleanly on top of the synced state.

## Commits

| Commit | What |
|---|---|
| `17f68699` | 3Pillar CI workflows (`azure-prod-build-push.yaml`, `lab-deploy-build-push.yaml`) — squashed from 7 incremental tweaks that converged on these final files |
| `3bb7e4c9` | Unique content handling: dedupe by `(content, path)` not content alone, so multiple files with identical content keep separate doc IDs |
| `4d32b0ae` | Local dev `docker-compose.yml` tweaks — comment out hkuds image (so compose builds from local source) and attach service to external `poc_network` |

## What this PR is NOT

- Not adding back `doc_ids` filter — that was the leaky cross-solution access control; obsoleted by per-request workspace isolation in the next PR (`feat/workspace-per-request`)
- Not adding back the old `TokenTracker` class — upstream has its own; the cost-tracking wiring lands in `feat/token-tracking-on-upstream`
- Not touching the API server or query path — `feat/workspace-per-request` does that

## Behavior change worth flagging

**Commit `3bb7e4c9` changes deduplication behavior.** Upstream LightRAG considers two files with identical text content as the same document. This commit makes them separate docs (keyed on `(content, path)` with `\0` as a collision-proof separator). The fork has been running with this behavior for a while; the commit preserves it.

If you'd rather match upstream's "dedupe by content only" approach, drop this commit and the other two still apply cleanly.

## Reviewer notes

Each commit is independently revertable. None touch the API server or storage adapters. The CI workflow additions don't modify any existing upstream-owned workflow file.

## Test plan

- [ ] `azure-prod-build-push.yaml` and `lab-deploy-build-push.yaml` resolve correctly in the GitHub Actions UI (no syntax errors)
- [ ] Upload two files with identical content but different filenames — confirm both land as separate `lightrag_doc_status` rows with different `doc-` IDs
- [ ] `docker-compose up` builds locally without needing to pull the hkuds image

🤖 Generated with [Claude Code](https://claude.com/claude-code)