### PR TITLE
Per-request workspace routing (registry + Depends-based handlers)

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -9,6 +9,7 @@ from fastapi.openapi.docs import (
     get_swagger_ui_html,
     get_swagger_ui_oauth2_redirect_html,
 )
+import asyncio
 import json
 import os
 import re
@@ -161,6 +162,60 @@ class LLMConfigCache:
                     "GeminiEmbeddingOptions not available, using default configuration"
                 )
                 self.gemini_embedding_options = {}
+
+
+class WorkspaceRegistry:
+    """Lazy registry of LightRAG instances keyed by workspace.
+
+    One process serves many workspaces: each request resolves to its own
+    LightRAG instance, but storage backends with ClientManager refcounting
+    (Postgres/Mongo/OpenSearch) share connection pools transparently.
+
+    Neo4j and Qdrant currently create per-instance drivers — fine for a
+    handful of workspaces, needs pool sharing in the storage layer to
+    scale to hundreds.
+    """
+
+    def __init__(self, factory, default_workspace=None):
+        # factory: (workspace: str | None) -> LightRAG
+        self._factory = factory
+        self._default_workspace = default_workspace or ""
+        self._instances: dict[str, "LightRAG"] = {}
+        self._lock = asyncio.Lock()
+
+    def _normalize(self, workspace):
+        # Empty string and None both map to the default workspace key.
+        return workspace if workspace else self._default_workspace
+
+    async def get(self, workspace):
+        key = self._normalize(workspace)
+        cached = self._instances.get(key)
+        if cached is not None:
+            return cached
+        async with self._lock:
+            cached = self._instances.get(key)
+            if cached is not None:
+                return cached
+            rag = self._factory(key or None)
+            await rag.initialize_storages()
+            self._instances[key] = rag
+            return rag
+
+    def register(self, workspace, rag):
+        self._instances[self._normalize(workspace)] = rag
+
+    def values(self):
+        return list(self._instances.values())
+
+    async def finalize_all(self):
+        for rag in self._instances.values():
+            try:
+                await rag.finalize_storages()
+            except Exception:
+                logger.exception(
+                    "Failed to finalize storages for workspace %r", rag.workspace
+                )
+        self._instances.clear()
 
 
 def check_frontend_build():
@@ -374,8 +429,13 @@ def create_app(args):
             yield
 
         finally:
-            # Clean up database connections
-            await rag.finalize_storages()
+            # Clean up database connections for every workspace instance
+            # that was lazily constructed during the server's lifetime.
+            registry = getattr(app.state, "workspace_registry", None)
+            if registry is not None:
+                await registry.finalize_all()
+            else:
+                await rag.finalize_storages()
 
             if "LIGHTRAG_GUNICORN_MODE" not in os.environ:
                 # Only perform cleanup in Uvicorn single-process mode
@@ -1163,11 +1223,16 @@ def create_app(args):
         name=args.simulated_model_name, tag=args.simulated_model_tag
     )
 
-    # Initialize RAG with unified configuration
-    try:
-        rag = LightRAG(
+    def _build_rag(workspace):
+        """Construct a LightRAG instance bound to the given workspace.
+
+        Storage backends with refcounted ClientManager (Postgres/Mongo/OpenSearch)
+        share connection pools across instances. Neo4j/Qdrant create per-instance
+        drivers — TODO: add pool sharing for high-cardinality workspace scale.
+        """
+        return LightRAG(
             working_dir=args.working_dir,
-            workspace=args.workspace,
+            workspace=workspace if workspace is not None else args.workspace,
             llm_model_func=create_llm_model_func(args.llm_binding),
             llm_model_name=args.llm_model,
             llm_model_max_async=args.max_async,
@@ -1199,18 +1264,40 @@ def create_app(args):
             },
             ollama_server_infos=ollama_server_infos,
         )
+
+    # Initialize RAG for the default workspace; further workspaces are
+    # constructed lazily by the registry on first request.
+    try:
+        rag = _build_rag(args.workspace)
     except Exception as e:
         logger.error(f"Failed to initialize LightRAG: {e}")
         raise
 
+    workspace_registry = WorkspaceRegistry(
+        factory=_build_rag, default_workspace=args.workspace
+    )
+    workspace_registry.register(args.workspace, rag)
+    app.state.workspace_registry = workspace_registry
+
+    async def get_rag(request: Request) -> LightRAG:
+        """Resolve the LightRAG instance for this request via the LIGHTRAG-WORKSPACE header."""
+        workspace = get_workspace_from_request(request)
+        return await workspace_registry.get(workspace)
+
     # Add routes
     # root_path is set on the app for reverse proxy support;
     # routes stay at their natural paths and are prefixed by the proxy or uvicorn --root-path
+    #
+    # Per-request workspace resolution is rolled out incrementally: /query already
+    # honors the LIGHTRAG-WORKSPACE header. /documents and /graph still resolve to
+    # the default workspace and will move to get_rag in follow-up commits.
     app.include_router(create_document_routes(rag, doc_manager, api_key))
-    app.include_router(create_query_routes(rag, api_key, args.top_k))
+    app.include_router(create_query_routes(get_rag, api_key, args.top_k))
     app.include_router(create_graph_routes(rag, api_key))
 
-    # Add Ollama API routes
+    # Add Ollama API routes — Ollama compatibility surface stays bound to the
+    # default workspace for now. Cross-workspace Ollama support is a follow-up
+    # once /query is validated.
     ollama_api = OllamaAPI(rag, top_k=args.top_k, api_key=api_key)
     app.include_router(ollama_api.router, prefix="/api")
 

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1288,12 +1288,12 @@ def create_app(args):
     # root_path is set on the app for reverse proxy support;
     # routes stay at their natural paths and are prefixed by the proxy or uvicorn --root-path
     #
-    # Per-request workspace resolution is rolled out incrementally: /query already
-    # honors the LIGHTRAG-WORKSPACE header. /documents and /graph still resolve to
-    # the default workspace and will move to get_rag in follow-up commits.
-    app.include_router(create_document_routes(rag, doc_manager, api_key))
+    # /query, /documents, and /graph all resolve the LightRAG instance per
+    # request via the LIGHTRAG-WORKSPACE header. The Ollama compatibility
+    # surface still binds to the default workspace.
+    app.include_router(create_document_routes(get_rag, doc_manager, api_key))
     app.include_router(create_query_routes(get_rag, api_key, args.top_k))
-    app.include_router(create_graph_routes(rag, api_key))
+    app.include_router(create_graph_routes(get_rag, api_key))
 
     # Add Ollama API routes — Ollama compatibility surface stays bound to the
     # default workspace for now. Cross-workspace Ollama support is a follow-up

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -19,6 +19,7 @@ from fastapi import (
     Depends,
     File,
     HTTPException,
+    Request,
     UploadFile,
 )
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -2087,7 +2088,7 @@ async def background_delete_documents(
 
 
 def create_document_routes(
-    rag: LightRAG, doc_manager: DocumentManager, api_key: Optional[str] = None
+    get_rag, doc_manager: DocumentManager, api_key: Optional[str] = None
 ):
     # Fresh router per call — see the note above the temp_prefix constant.
     router = APIRouter(
@@ -2098,10 +2099,17 @@ def create_document_routes(
     # Create combined auth dependency for document routes
     combined_auth = get_combined_auth_dependency(api_key)
 
+    async def _rag_dep(request: Request) -> LightRAG:
+        """Resolve the LightRAG instance for this request's workspace."""
+        return await get_rag(request)
+
     @router.post(
         "/scan", response_model=ScanResponse, dependencies=[Depends(combined_auth)]
     )
-    async def scan_for_new_documents(background_tasks: BackgroundTasks):
+    async def scan_for_new_documents(
+        background_tasks: BackgroundTasks,
+        rag: LightRAG = Depends(_rag_dep),
+    ):
         """
         Trigger the scanning process for new documents.
 
@@ -2127,7 +2135,9 @@ def create_document_routes(
         "/upload", response_model=InsertResponse, dependencies=[Depends(combined_auth)]
     )
     async def upload_to_input_dir(
-        background_tasks: BackgroundTasks, file: UploadFile = File(...)
+        background_tasks: BackgroundTasks,
+        file: UploadFile = File(...),
+        rag: LightRAG = Depends(_rag_dep),
     ):
         """
         Upload a file to the input directory and index it.
@@ -2295,7 +2305,9 @@ def create_document_routes(
         "/text", response_model=InsertResponse, dependencies=[Depends(combined_auth)]
     )
     async def insert_text(
-        request: InsertTextRequest, background_tasks: BackgroundTasks
+        request: InsertTextRequest,
+        background_tasks: BackgroundTasks,
+        rag: LightRAG = Depends(_rag_dep),
     ):
         """
         Insert text into the RAG system.
@@ -2375,7 +2387,9 @@ def create_document_routes(
         dependencies=[Depends(combined_auth)],
     )
     async def insert_texts(
-        request: InsertTextsRequest, background_tasks: BackgroundTasks
+        request: InsertTextsRequest,
+        background_tasks: BackgroundTasks,
+        rag: LightRAG = Depends(_rag_dep),
     ):
         """
         Insert multiple texts into the RAG system.
@@ -2455,7 +2469,7 @@ def create_document_routes(
     @router.delete(
         "", response_model=ClearDocumentsResponse, dependencies=[Depends(combined_auth)]
     )
-    async def clear_documents():
+    async def clear_documents(rag: LightRAG = Depends(_rag_dep)):
         """
         Clear all documents from the RAG system.
 
@@ -2651,7 +2665,9 @@ def create_document_routes(
         dependencies=[Depends(combined_auth)],
         response_model=PipelineStatusResponse,
     )
-    async def get_pipeline_status() -> PipelineStatusResponse:
+    async def get_pipeline_status(
+        rag: LightRAG = Depends(_rag_dep),
+    ) -> PipelineStatusResponse:
         """
         Get the current status of the document indexing pipeline.
 
@@ -2750,7 +2766,9 @@ def create_document_routes(
     @router.get(
         "", response_model=DocsStatusesResponse, dependencies=[Depends(combined_auth)]
     )
-    async def documents() -> DocsStatusesResponse:
+    async def documents(
+        rag: LightRAG = Depends(_rag_dep),
+    ) -> DocsStatusesResponse:
         """
         Get the status of all documents in the system. This endpoint is deprecated; use /documents/paginated instead.
         To prevent excessive resource consumption, a maximum of 1,000 records is returned.
@@ -2866,6 +2884,7 @@ def create_document_routes(
     async def delete_document(
         delete_request: DeleteDocRequest,
         background_tasks: BackgroundTasks,
+        rag: LightRAG = Depends(_rag_dep),
     ) -> DeleteDocByIdResponse:
         """
         Delete documents and all their associated data by their IDs using background processing.
@@ -2941,7 +2960,9 @@ def create_document_routes(
         response_model=ClearCacheResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def clear_cache(request: ClearCacheRequest):
+    async def clear_cache(
+        request: ClearCacheRequest, rag: LightRAG = Depends(_rag_dep)
+    ):
         """
         Clear all cache data from the LLM response cache storage.
 
@@ -2975,7 +2996,9 @@ def create_document_routes(
         response_model=DeletionResult,
         dependencies=[Depends(combined_auth)],
     )
-    async def delete_entity(request: DeleteEntityRequest):
+    async def delete_entity(
+        request: DeleteEntityRequest, rag: LightRAG = Depends(_rag_dep)
+    ):
         """
         Delete an entity and all its relationships from the knowledge graph.
 
@@ -3010,7 +3033,9 @@ def create_document_routes(
         response_model=DeletionResult,
         dependencies=[Depends(combined_auth)],
     )
-    async def delete_relation(request: DeleteRelationRequest):
+    async def delete_relation(
+        request: DeleteRelationRequest, rag: LightRAG = Depends(_rag_dep)
+    ):
         """
         Delete a relationship between two entities from the knowledge graph.
 
@@ -3048,7 +3073,9 @@ def create_document_routes(
         response_model=TrackStatusResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def get_track_status(track_id: str) -> TrackStatusResponse:
+    async def get_track_status(
+        track_id: str, rag: LightRAG = Depends(_rag_dep)
+    ) -> TrackStatusResponse:
         """
         Get the processing status of documents by tracking ID.
 
@@ -3124,6 +3151,7 @@ def create_document_routes(
     )
     async def get_documents_paginated(
         request: DocumentsRequest,
+        rag: LightRAG = Depends(_rag_dep),
     ) -> PaginatedDocsResponse:
         """
         Get documents with pagination support.
@@ -3301,7 +3329,9 @@ def create_document_routes(
         response_model=StatusCountsResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def get_document_status_counts() -> StatusCountsResponse:
+    async def get_document_status_counts(
+        rag: LightRAG = Depends(_rag_dep),
+    ) -> StatusCountsResponse:
         """
         Get counts of documents by status.
 
@@ -3328,7 +3358,9 @@ def create_document_routes(
         response_model=ReprocessResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def reprocess_failed_documents(background_tasks: BackgroundTasks):
+    async def reprocess_failed_documents(
+        background_tasks: BackgroundTasks, rag: LightRAG = Depends(_rag_dep)
+    ):
         """
         Reprocess failed and pending documents.
 
@@ -3374,7 +3406,7 @@ def create_document_routes(
         response_model=CancelPipelineResponse,
         dependencies=[Depends(combined_auth)],
     )
-    async def cancel_pipeline():
+    async def cancel_pipeline(rag: LightRAG = Depends(_rag_dep)):
         """
         Request cancellation of the currently running pipeline.
 

--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -4,7 +4,9 @@ This module contains all graph-related routes for the LightRAG API.
 
 from typing import Optional, Dict, Any
 import traceback
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Query, HTTPException, Request
+
+from lightrag import LightRAG
 from pydantic import BaseModel, Field
 
 from lightrag.utils import logger
@@ -84,7 +86,7 @@ class RelationCreateRequest(BaseModel):
     )
 
 
-def create_graph_routes(rag, api_key: Optional[str] = None):
+def create_graph_routes(get_rag, api_key: Optional[str] = None):
     # Fresh router per call. A module-level instance would accumulate
     # duplicate routes when the factory is invoked more than once in the
     # same process (e.g. across tests), which triggers FastAPI's
@@ -93,8 +95,12 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
 
     combined_auth = get_combined_auth_dependency(api_key)
 
+    async def _rag_dep(request: Request) -> LightRAG:
+        """Resolve the LightRAG instance for this request's workspace."""
+        return await get_rag(request)
+
     @router.get("/graph/label/list", dependencies=[Depends(combined_auth)])
-    async def get_graph_labels():
+    async def get_graph_labels(rag: LightRAG = Depends(_rag_dep)):
         """
         Get all graph labels
 
@@ -115,6 +121,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         limit: int = Query(
             300, description="Maximum number of popular labels to return", ge=1, le=1000
         ),
+        rag: LightRAG = Depends(_rag_dep),
     ):
         """
         Get popular labels by node degree (most connected entities)
@@ -140,6 +147,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         limit: int = Query(
             50, description="Maximum number of search results to return", ge=1, le=100
         ),
+        rag: LightRAG = Depends(_rag_dep),
     ):
         """
         Search labels with fuzzy matching
@@ -165,6 +173,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         label: str = Query(..., description="Label to get knowledge graph for"),
         max_depth: int = Query(3, description="Maximum depth of graph", ge=1),
         max_nodes: int = Query(1000, description="Maximum nodes to return", ge=1),
+        rag: LightRAG = Depends(_rag_dep),
     ):
         """
         Retrieve a connected subgraph of nodes where the label includes the specified label.
@@ -201,6 +210,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
     @router.get("/graph/entity/exists", dependencies=[Depends(combined_auth)])
     async def check_entity_exists(
         name: str = Query(..., description="Entity name to check"),
+        rag: LightRAG = Depends(_rag_dep),
     ):
         """
         Check if an entity with the given name exists in the knowledge graph
@@ -222,7 +232,9 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/entity/edit", dependencies=[Depends(combined_auth)])
-    async def update_entity(request: EntityUpdateRequest):
+    async def update_entity(
+        request: EntityUpdateRequest, rag: LightRAG = Depends(_rag_dep)
+    ):
         """
         Update an entity's properties in the knowledge graph
 
@@ -412,7 +424,9 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/relation/edit", dependencies=[Depends(combined_auth)])
-    async def update_relation(request: RelationUpdateRequest):
+    async def update_relation(
+        request: RelationUpdateRequest, rag: LightRAG = Depends(_rag_dep)
+    ):
         """Update a relation's properties in the knowledge graph
 
         Args:
@@ -447,7 +461,9 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/entity/create", dependencies=[Depends(combined_auth)])
-    async def create_entity(request: EntityCreateRequest):
+    async def create_entity(
+        request: EntityCreateRequest, rag: LightRAG = Depends(_rag_dep)
+    ):
         """
         Create a new entity in the knowledge graph
 
@@ -520,7 +536,9 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/relation/create", dependencies=[Depends(combined_auth)])
-    async def create_relation(request: RelationCreateRequest):
+    async def create_relation(
+        request: RelationCreateRequest, rag: LightRAG = Depends(_rag_dep)
+    ):
         """
         Create a new relationship between two entities in the knowledge graph
 
@@ -609,7 +627,9 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             )
 
     @router.post("/graph/entities/merge", dependencies=[Depends(combined_auth)])
-    async def merge_entities(request: EntityMergeRequest):
+    async def merge_entities(
+        request: EntityMergeRequest, rag: LightRAG = Depends(_rag_dep)
+    ):
         """
         Merge multiple entities into a single entity, preserving all relationships
 

--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -197,6 +197,10 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
 
     combined_auth = get_combined_auth_dependency(api_key)
 
+    async def _rag_dep(request: Request):
+        """Resolve the LightRAG instance for this request's workspace."""
+        return await get_rag(request)
+
     @router.post(
         "/query",
         response_model=QueryResponse,
@@ -326,7 +330,7 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
             },
         },
     )
-    async def query_text(request: QueryRequest, http_request: Request):
+    async def query_text(request: QueryRequest, rag=Depends(_rag_dep)):
         """
         Comprehensive RAG query endpoint with non-streaming response. Parameter "stream" is ignored.
 
@@ -413,7 +417,6 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
             param.stream = False
 
             # Unified approach: always use aquery_llm for both cases
-            rag = await get_rag(http_request)
             result = await rag.aquery_llm(request.query, param=param)
 
             # Extract LLM response and references from unified result
@@ -537,7 +540,7 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
             },
         },
     )
-    async def query_text_stream(request: QueryRequest, http_request: Request):
+    async def query_text_stream(request: QueryRequest, rag=Depends(_rag_dep)):
         """
         Advanced RAG query endpoint with flexible streaming response.
 
@@ -672,7 +675,6 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
             from fastapi.responses import StreamingResponse
 
             # Unified approach: always use aquery_llm for all cases
-            rag = await get_rag(http_request)
             result = await rag.aquery_llm(request.query, param=param)
 
             async def stream_generator():
@@ -1041,7 +1043,7 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
             },
         },
     )
-    async def query_data(request: QueryRequest, http_request: Request):
+    async def query_data(request: QueryRequest, rag=Depends(_rag_dep)):
         """
         Advanced data retrieval endpoint for structured RAG analysis.
 
@@ -1146,7 +1148,6 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
         """
         try:
             param = request.to_query_params(False)  # No streaming for data endpoint
-            rag = await get_rag(http_request)
             response = await rag.aquery_data(request.query, param=param)
 
             # aquery_data returns the new format with status, message, data, and metadata

--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -4,7 +4,7 @@ This module contains all query-related routes for the LightRAG API.
 
 import json
 from typing import Any, Dict, List, Literal, Optional
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from lightrag.base import QueryParam
 from lightrag.api.utils_api import get_combined_auth_dependency
 from lightrag.utils import logger
@@ -188,7 +188,7 @@ class StreamChunkResponse(BaseModel):
     )
 
 
-def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
+def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60):
     # Fresh router per call. A module-level instance would accumulate
     # duplicate routes when the factory is invoked more than once in the
     # same process (e.g. across tests), which triggers FastAPI's
@@ -326,7 +326,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             },
         },
     )
-    async def query_text(request: QueryRequest):
+    async def query_text(request: QueryRequest, http_request: Request):
         """
         Comprehensive RAG query endpoint with non-streaming response. Parameter "stream" is ignored.
 
@@ -413,6 +413,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             param.stream = False
 
             # Unified approach: always use aquery_llm for both cases
+            rag = await get_rag(http_request)
             result = await rag.aquery_llm(request.query, param=param)
 
             # Extract LLM response and references from unified result
@@ -536,7 +537,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             },
         },
     )
-    async def query_text_stream(request: QueryRequest):
+    async def query_text_stream(request: QueryRequest, http_request: Request):
         """
         Advanced RAG query endpoint with flexible streaming response.
 
@@ -671,6 +672,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             from fastapi.responses import StreamingResponse
 
             # Unified approach: always use aquery_llm for all cases
+            rag = await get_rag(http_request)
             result = await rag.aquery_llm(request.query, param=param)
 
             async def stream_generator():
@@ -1039,7 +1041,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             },
         },
     )
-    async def query_data(request: QueryRequest):
+    async def query_data(request: QueryRequest, http_request: Request):
         """
         Advanced data retrieval endpoint for structured RAG analysis.
 
@@ -1144,6 +1146,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
         """
         try:
             param = request.to_query_params(False)  # No streaming for data endpoint
+            rag = await get_rag(http_request)
             response = await rag.aquery_data(request.query, param=param)
 
             # aquery_data returns the new format with status, message, data, and metadata

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -449,7 +449,10 @@ class QdrantVectorDBStorage(BaseVectorStorage):
             # Fallback: use legacy namespace if model_suffix is unavailable
             self.final_namespace = f"lightrag_vdb_{self.namespace}"
             logger.warning(
-                f"Qdrant collection: {self.final_namespace} missing suffix. Pls add model_name to embedding_func for proper workspace data isolation."
+                f"Qdrant collection: {self.final_namespace} missing model suffix. "
+                "Add model_name to embedding_func for embedding-model isolation "
+                "(separate collections per model). Workspace isolation is "
+                "unaffected — it is enforced via the workspace_id payload filter."
             )
 
         kwargs = self.global_config.get("vector_db_storage_cls_kwargs", {})


### PR DESCRIPTION
## Summary

One LightRAG process now serves many workspaces, routing each HTTP request to the right `LightRAG` instance via the `LIGHTRAG-WORKSPACE` header. This is the natural completion of work upstream started — `get_workspace_from_request` already exists in upstream but only `/status` honored it; `/query`, `/documents`, and `/graph` all closed over a single boot-time `LightRAG` instance.

**~190 lines across 4 files, three commits.**

## Stacked on top of #11

This PR targets `chore/reapply-fork-keeps` so the diff shows only the workspace work. **Retarget to `develop` once #10 and #11 merge.**

## Why this matters

Without this, multi-tenant deployment requires one server container per workspace. Heading toward 1000 solutions, that's untenable. The storage layer's workspace isolation pattern is already in upstream (Postgres `workspace` column, Qdrant `workspace_id` payload, Neo4j label-based tagging) — only the HTTP-routing layer was missing.

## What changed

### `lightrag_server.py`
- **`WorkspaceRegistry` class** — lazy dict of `LightRAG` instances keyed by workspace, with `asyncio.Lock` for safe double-check-locked construction.
- **`_build_rag(workspace)`** — factory closure inside `create_app` that captures all the LLM/embedding/storage configuration once. The default workspace is built eagerly at startup and registered; additional workspaces are constructed lazily on first request.
- **`get_rag(request)` closure** — reads `LIGHTRAG-WORKSPACE` via upstream's existing `get_workspace_from_request` helper, then resolves through the registry.
- **Lifespan teardown** now calls `registry.finalize_all()` so every workspace's storages get cleaned up on shutdown.

### `query_routes.py`, `document_routes.py`, `graph_routes.py`
- Route factories take `get_rag` instead of `rag`.
- Every handler uses FastAPI's `Depends(_rag_dep)` to resolve the per-request workspace. Bodies that reference `rag.foo()` work unchanged because `rag` is now a function parameter.
- 30 handlers refactored total (3 in `/query`, 17 in `/documents`, 10 in `/graph`).

### `qdrant_impl.py`
- Misleading warning clarified: the `missing model suffix` log was about embedding-model isolation, not workspace isolation. The text said the wrong thing and almost sent me down a path of "fixing" a non-existent isolation gap.

## Backward compatibility

Missing/empty `LIGHTRAG-WORKSPACE` header falls through to `args.workspace` (env var). Existing deployments setting `WORKSPACE=...` keep working unchanged. We recommend setting `WORKSPACE=platform_docs` as a defensive default on deploy.

## Storage pool sharing — already works

Postgres, Mongo, and OpenSearch use upstream's `ClientManager` refcounted singleton pattern. **1,000 `LightRAG` instances in one process share ONE asyncpg connection pool**, ONE Mongo client, etc. No additional pool work required for these backends.

## Tested

Validated end-to-end on a real running stack with two workspaces (`platform_docs` and `solution_2550`) sharing Postgres + Neo4j + Qdrant + Redis:

| Storage | platform_docs | solution_2550 | Cross-contamination |
|---|---|---|---|
| Postgres `doc_status` | 22 docs | 10 docs | None |
| Neo4j (label-tagged) | 581 nodes | 88 nodes | None |
| Qdrant `vdb_chunks` | 91 points | 9 points | None |
| Qdrant `vdb_entities` | 581 points | 88 points | None |
| Qdrant `vdb_relationships` | 628 points | 82 points | None |

Confirmed:
- Lazy construction: `Creating LightRAG instance with workspace='X'` log fires exactly once per new workspace
- Registry caches correctly: repeat requests for same workspace don't rebuild
- Default workspace registered at startup is reused without rebuild (no log fires for header-less requests)

## Known follow-ups (NOT in this PR)

- **Ollama compatibility surface** still binds to the default workspace. Documented in code. Move to per-request only if Ollama-format clients need multi-workspace.
- **Neo4j and Qdrant create per-instance drivers** rather than sharing via ClientManager. Fine for handfuls of workspaces, needs pool sharing in the storage layer for >100 workspaces. Code TODOs flag the spot.

## Reviewer notes

Load-bearing change. The non-obvious bits:
1. `WorkspaceRegistry.get()` — double-check-locked lazy construction (`async with self._lock`, recheck cached, then build)
2. `_build_rag` closure — captures `args`, `embedding_func`, `rerank_model_func`, `ollama_server_infos`, etc. Compare against the prior `rag = LightRAG(...)` to verify nothing was lost
3. Route signatures — each handler gained `rag: LightRAG = Depends(_rag_dep)`. Handlers don't need to await `get_rag` themselves; FastAPI resolves it before calling the handler
4. Lifespan teardown — iterates `registry.values()` and finalizes each. Watch for double-finalize on the default workspace (it isn't, since it's only registered once)

## Upstream-PR-ability

Strong candidate to push back to HKUDS/LightRAG. We're finishing work HKUDS started (the `LIGHTRAG-WORKSPACE` header + sanitization + storage-layer isolation are all upstream's; only the route plumbing was missing). Reduces fork delta long-term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Deploy procedure (data cutover)

Existing LightRAG data is tagged `workspace='default'`. After this PR + the rest of the chain ship, requests with `LIGHTRAG-WORKSPACE: solution_N` will see empty workspaces. The cutover is fully scripted:

- **Wipe**: https://github.com/3PillarGlobal-Innovation/LightRAG/pull/14 — `scripts/wipe_storage.py` empties LightRAG state across Postgres / Neo4j / Qdrant / Redis (preserving backend Redis state).
- **Reingest**: https://github.com/3PillarGlobal-Innovation/application-modernization/pull/1153 — `data_scripts/reingest_from_backend.py` repopulates by reading every original document body from `lightrag_documents.document_metadata->>original_content`. No users are asked to re-upload.

The reingest script POSTs each doc to `/documents/upload` with the correct `LIGHTRAG-WORKSPACE` header — exercising the new routing introduced in this PR end-to-end.

Estimated maintenance window per environment: ~15 min, dominated by entity-extraction time during reingest.