### PR TITLE
Token tracking on top of upstream's TokenTracker

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -848,7 +848,7 @@ def create_app(args):
         # Step 3: Create optimized embedding function (calls underlying function directly)
         # Note: When model is None, each binding will use its own default model
         async def optimized_embedding_function(
-            texts, embedding_dim=None, context="document"
+            texts, embedding_dim=None, context="document", token_tracker=None
         ):
             try:
                 if binding == "lollms":
@@ -919,6 +919,8 @@ def create_app(args):
                             kwargs["query_prefix"] = query_prefix
                         if document_prefix:
                             kwargs["document_prefix"] = document_prefix
+                    if token_tracker is not None:
+                        kwargs["token_tracker"] = token_tracker
                     return await actual_func(**kwargs)
                 elif binding == "aws_bedrock":
                     from lightrag.llm.bedrock import bedrock_embed
@@ -984,6 +986,8 @@ def create_app(args):
                         kwargs["task_type"] = task_type
                     if provider_supports_asymmetric and asymmetric_opt_in:
                         kwargs["context"] = context
+                    if token_tracker is not None:
+                        kwargs["token_tracker"] = token_tracker
                     return await actual_func(**kwargs)
                 elif binding == "voyageai":
                     from lightrag.llm.voyageai import voyageai_embed
@@ -1026,6 +1030,8 @@ def create_app(args):
                             kwargs["query_prefix"] = query_prefix
                         if document_prefix:
                             kwargs["document_prefix"] = document_prefix
+                    if token_tracker is not None:
+                        kwargs["token_tracker"] = token_tracker
                     return await actual_func(**kwargs)
             except ImportError as e:
                 raise Exception(f"Failed to import {binding} embedding: {e}")

--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -184,6 +184,39 @@ class TokenUsageResponse(BaseModel):
     )
 
 
+def _build_token_usage_response(result: Dict[str, Any]) -> Optional["TokenUsageResponse"]:
+    """Shape aquery_llm's flat token_usage / embedding_token_usage dicts into
+    the response model the backend's cost logger expects.
+
+    Returns None when nothing was tracked (e.g. cache-only path with no LLM
+    or embedding calls), so the response field stays clean.
+    """
+    raw_llm = result.get("token_usage") or {}
+    raw_emb = result.get("embedding_token_usage") or {}
+    if not raw_llm.get("call_count") and not raw_emb.get("call_count"):
+        return None
+    return TokenUsageResponse(
+        llm=TokenCountResponse(
+            prompt_tokens=raw_llm.get("prompt_tokens", 0),
+            completion_tokens=raw_llm.get("completion_tokens", 0),
+            total_tokens=raw_llm.get("total_tokens", 0),
+            call_count=raw_llm.get("call_count", 0),
+        )
+        if raw_llm.get("call_count")
+        else None,
+        embedding=TokenCountResponse(
+            prompt_tokens=raw_emb.get("prompt_tokens", 0),
+            completion_tokens=raw_emb.get("completion_tokens", 0),
+            total_tokens=raw_emb.get("total_tokens", 0),
+            call_count=raw_emb.get("call_count", 0),
+        )
+        if raw_emb.get("call_count")
+        else None,
+        llm_model_name=result.get("model_name"),
+        embedding_model_name=result.get("embedding_model_name"),
+    )
+
+
 class QueryResponse(BaseModel):
     response: str = Field(
         description="The generated response",
@@ -459,6 +492,7 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
             llm_response = result.get("llm_response", {})
             data = result.get("data", {})
             references = data.get("references", [])
+            token_usage = _build_token_usage_response(result)
 
             # Get the non-streaming response content
             response_content = llm_response.get("content", "")
@@ -490,9 +524,17 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
 
             # Return response with or without references based on request
             if request.include_references:
-                return QueryResponse(response=response_content, references=references)
+                return QueryResponse(
+                    response=response_content,
+                    references=references,
+                    token_usage=token_usage,
+                )
             else:
-                return QueryResponse(response=response_content, references=None)
+                return QueryResponse(
+                    response=response_content,
+                    references=None,
+                    token_usage=token_usage,
+                )
         except Exception as e:
             logger.error(f"Error processing query: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
@@ -742,6 +784,11 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
                         enriched_references.append(ref_copy)
                     references = enriched_references
 
+                token_usage = _build_token_usage_response(result)
+                token_usage_dump = (
+                    token_usage.model_dump(exclude_none=True) if token_usage else None
+                )
+
                 if llm_response.get("is_streaming"):
                     # Streaming mode: send references first, then stream response chunks
                     if request.include_references:
@@ -756,6 +803,11 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
                         except Exception as e:
                             logger.error(f"Streaming error: {str(e)}")
                             yield f"{json.dumps({'error': str(e)})}\n"
+
+                    # Emit token usage as the final NDJSON frame so streaming
+                    # clients can record cost without re-querying.
+                    if token_usage_dump is not None:
+                        yield f"{json.dumps({'token_usage': token_usage_dump})}\n"
                 else:
                     # Non-streaming mode: send complete response in one message
                     response_content = llm_response.get("content", "")
@@ -766,6 +818,8 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
                     complete_response = {"response": response_content}
                     if request.include_references:
                         complete_response["references"] = references
+                    if token_usage_dump is not None:
+                        complete_response["token_usage"] = token_usage_dump
 
                     yield f"{json.dumps(complete_response)}\n"
 

--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -152,6 +152,38 @@ class ReferenceItem(BaseModel):
     )
 
 
+class TokenCountResponse(BaseModel):
+    prompt_tokens: int = Field(default=0, description="Number of input tokens")
+    completion_tokens: int = Field(default=0, description="Number of output tokens")
+    total_tokens: int = Field(
+        default=0, description="Total tokens (prompt + completion)"
+    )
+    call_count: int = Field(default=0, description="Number of API calls made")
+
+
+class TokenUsageResponse(BaseModel):
+    """Token usage statistics for cost tracking.
+
+    `llm` covers the answer-generation LLM call (and any keyword-extraction
+    LLM calls). `embedding` covers the embedding-model calls made for query
+    retrieval. Model names are surfaced so cost calculation downstream can
+    pick the right rate card.
+    """
+
+    llm: Optional[TokenCountResponse] = Field(
+        default=None, description="LLM token usage"
+    )
+    embedding: Optional[TokenCountResponse] = Field(
+        default=None, description="Embedding token usage"
+    )
+    llm_model_name: Optional[str] = Field(
+        default=None, description="LLM model/deployment used"
+    )
+    embedding_model_name: Optional[str] = Field(
+        default=None, description="Embedding model/deployment used"
+    )
+
+
 class QueryResponse(BaseModel):
     response: str = Field(
         description="The generated response",
@@ -159,6 +191,10 @@ class QueryResponse(BaseModel):
     references: Optional[List[ReferenceItem]] = Field(
         default=None,
         description="Reference list (Disabled when include_references=False, /query/data always includes references.)",
+    )
+    token_usage: Optional[TokenUsageResponse] = Field(
+        default=None,
+        description="LLM + embedding token usage for cost calculation. None when tracking is unavailable for the request.",
     )
 
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -98,6 +98,7 @@ from lightrag.utils import (
     Tokenizer,
     TiktokenTokenizer,
     EmbeddingFunc,
+    TokenTracker,
     always_get_an_event_loop,
     compute_mdhash_id,
     lazy_external_import,
@@ -2911,6 +2912,32 @@ class LightRAG:
 
         global_config = asdict(self)
 
+        # Per-request token trackers. The LLM tracker is injected by wrapping
+        # llm_model_func via partial — any call through the wrapped func gets
+        # token_tracker=... passed to the provider, which records usage. The
+        # embedding tracker attaches to the live EmbeddingFunc wrapper for the
+        # duration of the query and is reset in `finally`.
+        llm_tracker = TokenTracker()
+        embedding_tracker = TokenTracker()
+
+        original_llm_func = global_config["llm_model_func"]
+        global_config["llm_model_func"] = partial(
+            original_llm_func, token_tracker=llm_tracker
+        )
+        if param.model_func is not None:
+            param = replace(param, model_func=partial(param.model_func, token_tracker=llm_tracker))
+
+        embedding_inner = getattr(self.embedding_func, "__wrapped__", self.embedding_func)
+        embedding_inner.token_tracker = embedding_tracker
+
+        def _build_token_usage_block() -> dict[str, Any]:
+            return {
+                "token_usage": llm_tracker.get_usage(),
+                "embedding_token_usage": embedding_tracker.get_usage(),
+                "model_name": self.llm_model_name,
+                "embedding_model_name": getattr(embedding_inner, "model_name", None),
+            }
+
         try:
             query_result = None
 
@@ -2961,6 +2988,7 @@ class LightRAG:
                             "response_iterator": None,
                             "is_streaming": False,
                         },
+                        **_build_token_usage_block(),
                     }
                 else:
                     return {
@@ -2973,6 +3001,7 @@ class LightRAG:
                             "response_iterator": response,
                             "is_streaming": True,
                         },
+                        **_build_token_usage_block(),
                     }
             else:
                 raise ValueError(f"Unknown mode {param.mode}")
@@ -2994,6 +3023,7 @@ class LightRAG:
                         "response_iterator": None,
                         "is_streaming": False,
                     },
+                    **_build_token_usage_block(),
                 }
 
             # Extract structured data from query result
@@ -3007,6 +3037,7 @@ class LightRAG:
                 else None,
                 "is_streaming": query_result.is_streaming,
             }
+            raw_data.update(_build_token_usage_block())
 
             return raw_data
 
@@ -3023,7 +3054,12 @@ class LightRAG:
                     "response_iterator": None,
                     "is_streaming": False,
                 },
+                **_build_token_usage_block(),
             }
+        finally:
+            # Detach the embedding tracker so future requests don't accidentally
+            # share usage state through the shared EmbeddingFunc wrapper.
+            embedding_inner.token_tracker = None
 
     def query_llm(
         self,

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1897,6 +1897,34 @@ class LightRAG:
                     chunks: dict[str, Any] = {}
                     content_data: dict[str, Any] | None = None
 
+                    # Per-doc indexing token trackers. Captures the LLM and
+                    # embedding usage spent indexing this one document so the
+                    # cost can be attributed downstream.
+                    # CAVEAT: with max_parallel_insert > 1, multiple docs share
+                    # these mutable hooks — recorded per-doc usage is
+                    # approximate (totals are correct, per-doc attribution is
+                    # fuzzy). Set MAX_PARALLEL_INSERT=1 for exact accounting.
+                    doc_llm_tracker = TokenTracker()
+                    doc_embedding_tracker = TokenTracker()
+                    original_llm_model_func = self.llm_model_func
+                    self.llm_model_func = partial(
+                        original_llm_model_func, token_tracker=doc_llm_tracker
+                    )
+                    embedding_inner = getattr(
+                        self.embedding_func, "__wrapped__", self.embedding_func
+                    )
+                    embedding_inner.token_tracker = doc_embedding_tracker
+
+                    def _doc_token_usage_metadata() -> dict[str, Any]:
+                        return {
+                            "llm_token_usage": doc_llm_tracker.get_usage(),
+                            "embedding_token_usage": doc_embedding_tracker.get_usage(),
+                            "llm_model_name": self.llm_model_name,
+                            "embedding_model_name": getattr(
+                                embedding_inner, "model_name", None
+                            ),
+                        }
+
                     def get_failed_chunk_snapshot() -> tuple[list[str], int]:
                         if chunks:
                             chunk_ids = list(chunks.keys())
@@ -2122,6 +2150,7 @@ class LightRAG:
                                         "metadata": {
                                             "processing_start_time": processing_start_time,
                                             "processing_end_time": processing_end_time,
+                                            **_doc_token_usage_metadata(),
                                         },
                                     }
                                 }
@@ -2179,6 +2208,7 @@ class LightRAG:
                                             "metadata": {
                                                 "processing_start_time": processing_start_time,
                                                 "processing_end_time": processing_end_time,
+                                                **_doc_token_usage_metadata(),
                                             },
                                         }
                                     }
@@ -2254,10 +2284,20 @@ class LightRAG:
                                             "metadata": {
                                                 "processing_start_time": processing_start_time,
                                                 "processing_end_time": processing_end_time,
+                                                **_doc_token_usage_metadata(),
                                             },
                                         }
                                     }
                                 )
+
+                    # Restore the original llm_model_func and clear the embedding
+                    # tracker now that this document is done. Done at the end of
+                    # process_document so the trackers don't leak across docs.
+                    # (The inner try/except blocks handle all expected failures,
+                    # so this point is reached on both success and handled
+                    # failure paths.)
+                    self.llm_model_func = original_llm_model_func
+                    embedding_inner.token_tracker = None
 
                 # Create processing tasks for all documents
                 doc_tasks = []

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1900,6 +1900,16 @@ class LightRAG:
                     # Per-doc indexing token trackers. Captures the LLM and
                     # embedding usage spent indexing this one document so the
                     # cost can be attributed downstream.
+                    #
+                    # IMPORTANT: we wrap llm_model_func with a *closure*, not
+                    # functools.partial. extract_entities reads the func via
+                    # `global_config = asdict(self)`, and `asdict` deep-copies
+                    # non-dataclass values — which would clone the partial's
+                    # `keywords` dict (including the TokenTracker), sending the
+                    # actual usage updates into a clone instead of our tracker.
+                    # Closures are deepcopy-immortal in Python, so the
+                    # `doc_llm_tracker` reference inside the closure survives.
+                    #
                     # CAVEAT: with max_parallel_insert > 1, multiple docs share
                     # these mutable hooks — recorded per-doc usage is
                     # approximate (totals are correct, per-doc attribution is
@@ -1907,9 +1917,12 @@ class LightRAG:
                     doc_llm_tracker = TokenTracker()
                     doc_embedding_tracker = TokenTracker()
                     original_llm_model_func = self.llm_model_func
-                    self.llm_model_func = partial(
-                        original_llm_model_func, token_tracker=doc_llm_tracker
-                    )
+
+                    async def _llm_with_tracker(*args, **kwargs):
+                        kwargs.setdefault("token_tracker", doc_llm_tracker)
+                        return await original_llm_model_func(*args, **kwargs)
+
+                    self.llm_model_func = _llm_with_tracker
                     embedding_inner = getattr(
                         self.embedding_func, "__wrapped__", self.embedding_func
                     )

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -468,6 +468,12 @@ class EmbeddingFunc:
     supports_asymmetric: bool = (
         False  # Whether underlying function accepts context parameter
     )
+    # Per-request token tracker. Callers set this on the live wrapper (e.g.
+    # `embedding_func.__wrapped__.token_tracker = tracker`) for the duration
+    # of a query/indexing pass, then reset to None. The wrapper passes it
+    # through to the underlying embedding function, which calls
+    # `token_tracker.add_usage(...)` after each provider call.
+    token_tracker: "TokenTracker | None" = None
 
     def __post_init__(self):
         """Unwrap nested EmbeddingFunc to prevent double wrapping issues.
@@ -529,6 +535,11 @@ class EmbeddingFunc:
             sig = inspect.signature(self.func)
             if "max_token_size" in sig.parameters:
                 kwargs["max_token_size"] = self.max_token_size
+
+        # Pass token_tracker through so the underlying provider records usage.
+        # Caller-supplied trackers take precedence over the wrapper-level one.
+        if self.token_tracker is not None and "token_tracker" not in kwargs:
+            kwargs["token_tracker"] = self.token_tracker
 
         # Call the actual embedding function
         result = await self.func(*args, **kwargs)
@@ -2045,6 +2056,7 @@ async def use_llm_func_with_cache(
     cache_type: str = "extract",
     chunk_id: str | None = None,
     cache_keys_collector: list = None,
+    token_tracker: "TokenTracker | None" = None,
 ) -> tuple[str, int]:
     """Call LLM function with cache support and text sanitization
 
@@ -2127,6 +2139,8 @@ async def use_llm_func_with_cache(
             kwargs["history_messages"] = safe_history_messages
         if max_tokens is not None:
             kwargs["max_tokens"] = max_tokens
+        if token_tracker is not None:
+            kwargs["token_tracker"] = token_tracker
 
         res: str = await use_llm_func(
             safe_user_prompt, system_prompt=safe_system_prompt, **kwargs
@@ -2161,6 +2175,8 @@ async def use_llm_func_with_cache(
         kwargs["history_messages"] = safe_history_messages
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
+    if token_tracker is not None:
+        kwargs["token_tracker"] = token_tracker
 
     try:
         res = await use_llm_func(


### PR DESCRIPTION
## Summary

Exposes per-request LLM and embedding token usage on the `/query`, `/query/stream`, and `/documents` responses, on top of upstream's existing `TokenTracker` class. The backend's `_log_token_usage_from_query` already expects exactly this response shape — once this PR is deployed alongside the matching backend PR, `api_cost_logs` rows start populating automatically.

**~130 lines across 4 files, six commits.**

## Stacked on top of #12

Targets `feat/workspace-per-request` so the diff shows only the cost-tracking work. **Retarget to `develop` once #10 → #11 → #12 merge.**

## Why this matters

Upstream ships a `TokenTracker` class (`utils.py:2624`) but only LLM providers know how to fill it — no HTTP-level wiring exists. The fork's `_log_token_usage_from_query` in the backend has been silently logging $0 for every query because no `token_usage` field comes back. This PR is the missing glue.

Verified: after this PR + the matching backend PR, `api_cost_logs` rows land with correct model name, token counts, dollar amounts, and `solution_id`.

## Commits

| Commit | What |
|---|---|
| `0fdd2cff` | Plumb `token_tracker` through `EmbeddingFunc.__call__` and `use_llm_func_with_cache` |
| `0486f808` | Per-request trackers in `aquery_llm` — wraps `llm_model_func` with partial(token_tracker=...) and sets the embedding wrapper's `token_tracker` for the request's duration |
| `689710a0` | Populate `token_usage` field on `/query` response + emit final NDJSON frame with usage on `/query/stream` |
| `f6ba0774` | Accept `token_tracker` in `optimized_embedding_function` (server-level dispatch) so the kwarg doesn't leak as an unexpected argument and kill embedding-based retrieval |
| `89dc22cb` | Per-document indexing trackers, persisted on `doc_status` row's metadata |
| `5a131ede` | **Bug fix**: use a closure instead of `partial` for the doc LLM wrap — `dataclasses.asdict` deepcopies non-dataclass values, sending usage updates to a clone instead of our tracker. Closures are deepcopy-immortal in Python |

## Response shape

```json
{
  "response": "...",
  "references": [...],
  "token_usage": {
    "llm":       {"prompt_tokens": 7245, "completion_tokens": 402, "total_tokens": 7647, "call_count": 2},
    "embedding": {"prompt_tokens":  277, "completion_tokens":   0, "total_tokens":  277, "call_count": 10},
    "llm_model_name": "gpt-4o-mini",
    "embedding_model_name": "..."
  }
}
```

Matches the backend's `_log_token_usage_from_query` contract exactly.

For `/query/stream`: same payload as a final NDJSON frame after content.

For `/documents`: per-doc usage shows up under `metadata.llm_token_usage` and `metadata.embedding_token_usage` on each doc row.

## CAVEAT — indexing-side parallelism

For per-doc indexing trackers (commits `89dc22cb`, `5a131ede`): when `MAX_PARALLEL_INSERT > 1`, concurrently processing documents share the LLM and embedding tracker hooks on the shared `LightRAG` instance. **Aggregate usage is correct; per-doc attribution is approximate.** Set `MAX_PARALLEL_INSERT=1` for exact per-doc accounting. The trade-off is documented in code.

## Tested live

- `/query` against `platform_docs` (Azure OpenAI gpt-4o-mini, text-embedding-3-large): `token_usage` populated with 1 LLM call (612+43 = 655 tokens) and 1 embedding call (26 tokens), real answer generated from retrieved chapters.
- `/documents/upload` to a fresh `closure_fix_test` workspace: doc finished `processed` with `metadata.llm_token_usage.call_count=2, total_tokens=7647` and `metadata.embedding_token_usage.call_count=10, total_tokens=277`.
- Backend's `api_cost_logs` table received rows with correct model name (`3pg-innovation-openai-gpt-4o`), token counts, dollar amounts ($0.099 for the LLM, $0.000002 for the embedding), and `solution_id=2550` from a real solution-scoped query.

## Reviewer notes

The non-obvious bits:
1. **Commit `5a131ede`** is a subtle bug fix. `functools.partial` looks like the right wrapper for the indexing LLM tracker, but `dataclasses.asdict(self)` later deepcopies the partial, cloning the `TokenTracker` reference. Updates land in the clone, leaving the original at 0. Closures are deepcopy-immortal — they're the right tool here. Worth reading the commit message.
2. **Why aquery_llm doesn't have the same bug**: it mutates `global_config` (a local dict) instead of `self`, so no further asdict happens. The partial pattern works there.
3. **`f6ba0774`** is small but load-bearing — without it, every embedding call during a tracked query raised TypeError, silently killing retrieval. The error was discovered via logs during the smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)