### PR TITLE
ops: scripts/wipe_storage.py + WebUI workspace selector

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1445,9 +1445,17 @@ def create_app(args):
             default_workspace = get_default_workspace()
             if workspace is None:
                 workspace = default_workspace
-            pipeline_status = await get_namespace_data(
-                "pipeline_status", workspace=workspace
-            )
+            try:
+                pipeline_status = await get_namespace_data(
+                    "pipeline_status", workspace=workspace
+                )
+            except Exception:
+                # The requested workspace hasn't been used yet, so its
+                # pipeline_status namespace doesn't exist in shared
+                # storage. Return an empty pipeline_status rather than
+                # 500-ing — /health is meant to be a cheap probe, not
+                # a workspace initializer.
+                pipeline_status = {}
 
             if not auth_configured:
                 auth_mode = "disabled"
@@ -1509,6 +1517,63 @@ def create_app(args):
             }
         except Exception as e:
             logger.error(f"Error getting health status: {str(e)}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.get(
+        "/workspaces",
+        dependencies=[Depends(combined_auth)],
+        summary="List known workspaces",
+        description=(
+            "Returns the distinct workspace names that currently have indexed "
+            "documents, plus the document count per workspace. Used by the "
+            "WebUI to populate the workspace selector. Currently only the "
+            "PGDocStatusStorage backend is fully supported; other backends "
+            "return just the registry-known workspaces."
+        ),
+    )
+    async def list_workspaces():
+        """Return [{workspace, doc_count}, ...] for the workspace selector."""
+        result: list[dict] = []
+        try:
+            # Fast path: PGDocStatusStorage exposes the storage's raw query method.
+            doc_status = getattr(rag, "doc_status", None)
+            db = getattr(doc_status, "db", None)
+            if db is not None and hasattr(db, "query"):
+                rows = await db.query(
+                    "SELECT workspace, COUNT(*) AS doc_count "
+                    "FROM lightrag_doc_status "
+                    "GROUP BY workspace "
+                    "ORDER BY workspace",
+                    multirows=True,
+                )
+                for r in rows or []:
+                    name = r.get("workspace") or ""
+                    result.append(
+                        {
+                            "workspace": name,
+                            "doc_count": int(r.get("doc_count") or 0),
+                        }
+                    )
+            else:
+                # Fallback: registry-known workspaces, no counts.
+                registry = getattr(app.state, "workspace_registry", None)
+                seen = set()
+                if registry is not None:
+                    for inst in registry.values():
+                        ws = getattr(inst, "workspace", "") or ""
+                        if ws not in seen:
+                            seen.add(ws)
+                            result.append({"workspace": ws, "doc_count": None})
+
+            # Always include the env-configured default so the UI can offer it
+            # even before anything has been indexed against it.
+            default_ws = (args.workspace or "").strip()
+            if default_ws and not any(r["workspace"] == default_ws for r in result):
+                result.append({"workspace": default_ws, "doc_count": 0})
+
+            return {"workspaces": result}
+        except Exception as e:
+            logger.error(f"Error listing workspaces: {str(e)}")
             raise HTTPException(status_code=500, detail=str(e))
 
     # Pre-render the runtime-config <script> once. The browser-visible URL

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -344,6 +344,7 @@ axiosInstance.interceptors.request.use((config) => {
 
   const apiKey = useSettingsStore.getState().apiKey
   const token = localStorage.getItem('LIGHTRAG-API-TOKEN');
+  const workspace = useSettingsStore.getState().workspace
 
   // Always include token if it exists, regardless of path
   if (token) {
@@ -351,6 +352,12 @@ axiosInstance.interceptors.request.use((config) => {
   }
   if (apiKey) {
     config.headers['X-API-Key'] = apiKey
+  }
+  // Per-request workspace routing. Empty string falls through to the
+  // server's WORKSPACE env var (e.g. platform_docs). Server sanitizes the
+  // header to [a-zA-Z0-9_], so a stray invalid char is harmless.
+  if (workspace) {
+    config.headers['LIGHTRAG-WORKSPACE'] = workspace
   }
   return config
 })
@@ -486,6 +493,20 @@ export const checkHealth = async (): Promise<
       message: errorMessage(error)
     }
   }
+}
+
+export type WorkspaceInfo = { workspace: string; doc_count: number | null }
+
+/**
+ * Fetch the list of workspaces that currently have indexed docs. Backed by
+ * the server's /workspaces endpoint, which is a meta endpoint — it ignores
+ * the LIGHTRAG-WORKSPACE header on the request and returns all workspaces
+ * known to the storage layer.
+ */
+export const getWorkspaces = async (): Promise<WorkspaceInfo[]> => {
+  const response = await axiosInstance.get('/workspaces')
+  const list = response?.data?.workspaces
+  return Array.isArray(list) ? list : []
 }
 
 export const getDocuments = async (): Promise<DocsStatusesResponse> => {

--- a/lightrag_webui/src/components/AppSettings.tsx
+++ b/lightrag_webui/src/components/AppSettings.tsx
@@ -1,11 +1,16 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover'
 import Button from '@/components/ui/Button'
+import Input from '@/components/ui/Input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select'
 import { useSettingsStore } from '@/stores/settings'
+import { getWorkspaces, type WorkspaceInfo } from '@/api/lightrag'
 import { PaletteIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
+
+const WORKSPACE_CUSTOM_SENTINEL = '__custom__'
+const WORKSPACE_DEFAULT_SENTINEL = '__default__'
 
 interface AppSettingsProps {
   className?: string
@@ -21,6 +26,41 @@ export default function AppSettings({ className }: AppSettingsProps) {
   const theme = useSettingsStore.use.theme()
   const setTheme = useSettingsStore.use.setTheme()
 
+  const workspace = useSettingsStore.use.workspace()
+  const setWorkspace = useSettingsStore.use.setWorkspace()
+  const [knownWorkspaces, setKnownWorkspaces] = useState<WorkspaceInfo[]>([])
+  const [workspaceMode, setWorkspaceMode] = useState<'select' | 'custom'>(
+    workspace ? 'select' : 'select'
+  )
+
+  // Refresh workspace list whenever the popover opens. Cheap call; lets the
+  // dropdown reflect any newly-indexed workspaces without a hard refresh.
+  useEffect(() => {
+    if (!opened) return
+    let cancelled = false
+    getWorkspaces()
+      .then((list) => {
+        if (cancelled) return
+        setKnownWorkspaces(list)
+        // If the currently-stored workspace isn't in the list, flip to
+        // custom-input mode so the user sees their value.
+        if (
+          workspace &&
+          !list.some((w) => w.workspace === workspace)
+        ) {
+          setWorkspaceMode('custom')
+        }
+      })
+      .catch(() => {
+        // /workspaces may not exist on older servers — silently fall back to
+        // custom-text input so the feature still works.
+        if (!cancelled) setWorkspaceMode('custom')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [opened, workspace])
+
   const handleLanguageChange = useCallback((value: string) => {
     setLanguage(value as 'en' | 'zh' | 'fr' | 'ar' | 'zh_TW' | 'ru' | 'ja' | 'de' | 'uk' | 'ko' | 'vi')
   }, [setLanguage])
@@ -28,6 +68,40 @@ export default function AppSettings({ className }: AppSettingsProps) {
   const handleThemeChange = useCallback((value: string) => {
     setTheme(value as 'light' | 'dark' | 'system')
   }, [setTheme])
+
+  const handleWorkspaceSelect = useCallback(
+    (value: string) => {
+      if (value === WORKSPACE_CUSTOM_SENTINEL) {
+        setWorkspaceMode('custom')
+        return
+      }
+      if (value === WORKSPACE_DEFAULT_SENTINEL) {
+        setWorkspace('')
+      } else {
+        setWorkspace(value)
+      }
+      setWorkspaceMode('select')
+      // Close the popover so the user sees the underlying view refresh.
+      setOpened(false)
+    },
+    [setWorkspace]
+  )
+
+  const handleWorkspaceChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setWorkspace(e.target.value)
+    },
+    [setWorkspace]
+  )
+
+  const dropdownValue = (() => {
+    if (workspaceMode === 'custom') return WORKSPACE_CUSTOM_SENTINEL
+    if (!workspace) return WORKSPACE_DEFAULT_SENTINEL
+    if (knownWorkspaces.some((w) => w.workspace === workspace)) return workspace
+    // Stored workspace isn't (yet) in the list — render the dropdown blank
+    // so the value doesn't visually clash with the available options.
+    return undefined
+  })()
 
   return (
     <Popover open={opened} onOpenChange={setOpened}>
@@ -72,6 +146,40 @@ export default function AppSettings({ className }: AppSettingsProps) {
                 <SelectItem value="system">{t('settings.system')}</SelectItem>
               </SelectContent>
             </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Workspace</label>
+            <Select value={dropdownValue ?? ''} onValueChange={handleWorkspaceSelect}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a workspace…" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={WORKSPACE_DEFAULT_SENTINEL}>(server default)</SelectItem>
+                {knownWorkspaces.map((w) => (
+                  <SelectItem key={w.workspace} value={w.workspace || WORKSPACE_DEFAULT_SENTINEL}>
+                    {w.workspace || '(empty)'}
+                    {w.doc_count !== null ? ` — ${w.doc_count} docs` : ''}
+                  </SelectItem>
+                ))}
+                <SelectItem value={WORKSPACE_CUSTOM_SENTINEL}>Custom…</SelectItem>
+              </SelectContent>
+            </Select>
+            {workspaceMode === 'custom' && (
+              <Input
+                type="text"
+                placeholder="solution_42"
+                value={workspace}
+                onChange={handleWorkspaceChange}
+                spellCheck={false}
+                autoCapitalize="off"
+                autoCorrect="off"
+              />
+            )}
+            <span className="text-xs text-muted-foreground">
+              Sends as <code>LIGHTRAG-WORKSPACE</code> header. Blank = server default
+              (e.g. <code>platform_docs</code>).
+            </span>
           </div>
         </div>
       </PopoverContent>

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -307,6 +307,7 @@ export default function DocumentManager() {
   const setShowFileName = useSettingsStore.use.setShowFileName()
   const documentsPageSize = useSettingsStore.use.documentsPageSize()
   const setDocumentsPageSize = useSettingsStore.use.setDocumentsPageSize()
+  const workspace = useSettingsStore.use.workspace()
 
   // New pagination state
   const [currentPageDocs, setCurrentPageDocs] = useState<DocStatusResponse[]>([])
@@ -1000,6 +1001,18 @@ export default function DocumentManager() {
   useEffect(() => {
     latestRefreshRequestVersionRef.current += 1
   }, [pagination.page, pagination.page_size, statusFilter, sortField, sortDirection])
+
+  // Workspace switch — refetch the document list immediately so the table
+  // reflects the newly-selected workspace's data. Without this, the API
+  // calls go out with the new LIGHTRAG-WORKSPACE header but the UI still
+  // shows the previous workspace's docs until the user does something
+  // else that triggers a refresh.
+  useEffect(() => {
+    if (currentTab === 'documents' && health && isMountedRef.current) {
+      handleIntelligentRefresh()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspace])
 
   // Monitor pipelineBusy changes and trigger immediate refresh with timer reset
   useEffect(() => {

--- a/lightrag_webui/src/stores/settings.ts
+++ b/lightrag_webui/src/stores/settings.ts
@@ -66,6 +66,13 @@ interface SettingsState {
   apiKey: string | null
   setApiKey: (key: string | null) => void
 
+  // Workspace selection — sent as the LIGHTRAG-WORKSPACE header on every API
+  // request. Empty string falls through to the server's args.workspace
+  // (e.g. WORKSPACE=platform_docs). Use values like "platform_docs" or
+  // "solution_42" to view those workspaces' data.
+  workspace: string
+  setWorkspace: (workspace: string) => void
+
   // App settings
   theme: Theme
   setTheme: (theme: Theme) => void
@@ -113,6 +120,8 @@ const useSettingsStoreBase = create<SettingsState>()(
       enableHealthCheck: true,
 
       apiKey: null,
+
+      workspace: '',
 
       currentTab: 'documents',
       showFileName: false,
@@ -183,6 +192,8 @@ const useSettingsStoreBase = create<SettingsState>()(
       setEnableHealthCheck: (enable: boolean) => set({ enableHealthCheck: enable }),
 
       setApiKey: (apiKey: string | null) => set({ apiKey }),
+
+      setWorkspace: (workspace: string) => set({ workspace: workspace.trim() }),
 
       setCurrentTab: (tab: Tab) => set({ currentTab: tab }),
 

--- a/scripts/wipe_storage.py
+++ b/scripts/wipe_storage.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Wipe every LightRAG-managed datum across Postgres, Neo4j, Qdrant, and Redis.
+
+Intended for the per-request-workspace migration cutover — see
+docs/MIGRATION_TO_PER_REQUEST_WORKSPACE.md (or the PR description for the
+workspace work) for the surrounding deploy procedure.
+
+WHAT THIS SCRIPT TOUCHES
+    - Postgres: drops and recreates the `lightrag` database
+    - Neo4j: DETACH DELETE every node
+    - Qdrant: deletes every collection
+    - Redis: deletes every LightRAG-owned key
+
+WHAT THIS SCRIPT PRESERVES IN REDIS
+    Backend-owned namespaces stay intact:
+      - `ingestion:*`     application ingestion tracking
+      - `schema:*`        application schema cache
+      - `arq:*`           async task queue state
+      - `llm_response_cache:default:*` (unprefixed) — preserved because it
+        is ambiguous: it could be either LightRAG's pre-workspace cache or
+        a backend cache sharing the same name. Treat as "may be backend's".
+        Workspace-prefixed `<workspace>_llm_response_cache:*` IS deleted.
+
+USAGE
+    # Dry run (default — prints what would change, no writes)
+    python scripts/wipe_storage.py
+
+    # Actually wipe
+    python scripts/wipe_storage.py --execute
+
+    # Wipe only one backend (handy when retrying after a partial failure)
+    python scripts/wipe_storage.py --only postgres --execute
+
+CREDENTIALS
+    Read from .env in the current working directory by default. Override
+    individual values via environment variables before running.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+# --- env loader (lightweight; avoids requiring python-dotenv) -----------------
+
+
+def load_env_file(path: Path) -> None:
+    if not path.exists():
+        return
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key, value)
+
+
+# --- backend wipers -----------------------------------------------------------
+
+
+def wipe_postgres(execute: bool) -> str:
+    """Drop and recreate the `lightrag` database. LightRAG will recreate the
+    schema on its next startup via the storage-init migration path.
+    """
+    import psycopg2  # type: ignore
+    from psycopg2 import sql
+
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    port = int(os.environ.get("POSTGRES_PORT", "5432"))
+    user = os.environ.get("POSTGRES_USER", "postgres")
+    password = os.environ.get("POSTGRES_PASSWORD", "")
+    dbname = os.environ.get("POSTGRES_DATABASE", "lightrag")
+
+    if not execute:
+        return f"would DROP/CREATE database {dbname!r} on {host}:{port}"
+
+    # We need to connect to a DB other than the one we're dropping.
+    conn = psycopg2.connect(
+        host=host, port=port, user=user, password=password, dbname="postgres"
+    )
+    conn.autocommit = True  # CREATE/DROP DATABASE can't run inside a transaction
+    try:
+        cur = conn.cursor()
+        # Terminate stragglers so DROP DATABASE doesn't error with
+        # "database is being accessed by other users".
+        cur.execute(
+            sql.SQL(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()"
+            ),
+            (dbname,),
+        )
+        cur.execute(sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname)))
+        cur.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(dbname)))
+    finally:
+        conn.close()
+    return f"dropped and recreated {dbname!r}"
+
+
+def wipe_neo4j(execute: bool) -> str:
+    """Detach-delete every node in the configured Neo4j database."""
+    from neo4j import GraphDatabase  # type: ignore
+
+    uri = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    username = os.environ.get("NEO4J_USERNAME", "neo4j")
+    password = os.environ.get("NEO4J_PASSWORD", "")
+    database = os.environ.get("NEO4J_DATABASE", "neo4j")
+
+    if not execute:
+        return f"would DETACH DELETE all nodes in Neo4j db {database!r} at {uri}"
+
+    driver = GraphDatabase.driver(uri, auth=(username, password))
+    try:
+        with driver.session(database=database) as session:
+            before = session.run("MATCH (n) RETURN count(n) AS c").single()["c"]
+            session.run("MATCH (n) DETACH DELETE n")
+            after = session.run("MATCH (n) RETURN count(n) AS c").single()["c"]
+        return f"Neo4j: deleted {before - after} nodes (was {before}, now {after})"
+    finally:
+        driver.close()
+
+
+def wipe_qdrant(execute: bool) -> str:
+    """Drop every Qdrant collection. LightRAG will recreate the ones it needs
+    on next startup using its workspace-aware naming.
+    """
+    from qdrant_client import QdrantClient  # type: ignore
+
+    url = os.environ.get("QDRANT_URL", "http://localhost:6333")
+    api_key = os.environ.get("QDRANT_API_KEY") or None
+
+    client = QdrantClient(url=url, api_key=api_key)
+    try:
+        existing = [c.name for c in client.get_collections().collections]
+    except Exception as e:
+        return f"Qdrant: failed to list collections ({e})"
+
+    if not execute:
+        return f"would delete {len(existing)} Qdrant collection(s): {existing}"
+
+    deleted = []
+    for name in existing:
+        try:
+            client.delete_collection(name)
+            deleted.append(name)
+        except Exception as e:
+            print(f"  [WARN] Qdrant: failed to drop {name}: {e}", file=sys.stderr)
+    return f"Qdrant: dropped {len(deleted)}/{len(existing)} collection(s)"
+
+
+_REDIS_LIGHTRAG_KEY_PATTERNS = (
+    # Legacy unprefixed namespaces that exist when LightRAG ran with an
+    # empty workspace before per-workspace prefixing was introduced.
+    "entity_chunks:*",
+    "relation_chunks:*",
+    "full_entities:*",
+    "full_relations:*",
+    "text_chunks:*",
+    "full_docs:doc-*",
+    # Anything LightRAG-prefixed by a workspace name follows the shape
+    # `<workspace>_<namespace>:...`. Iterating known workspaces from env keeps
+    # this surgical; passing --include-all-workspaces sweeps every key with
+    # the LightRAG namespace suffix regardless of prefix.
+)
+
+
+def _scan_keys(redis_client, pattern: str) -> Iterable[str]:
+    cursor = 0
+    while True:
+        cursor, batch = redis_client.scan(cursor=cursor, match=pattern, count=1000)
+        for key in batch:
+            yield key.decode() if isinstance(key, bytes) else key
+        if cursor == 0:
+            return
+
+
+def wipe_redis(execute: bool, include_all_workspaces: bool) -> str:
+    """Delete LightRAG-owned keys, preserving backend state.
+
+    Two sweep modes:
+        - surgical (default): only fixed legacy patterns + the workspace
+          patterns enumerated below
+        - --include-all-workspaces: also matches any key whose suffix is one
+          of LightRAG's known namespaces (handles unknown workspaces)
+    """
+    import redis  # type: ignore
+
+    url = os.environ.get("REDIS_URI") or os.environ.get("REDIS_URL")
+    if not url:
+        return "Redis: no REDIS_URI/REDIS_URL set, skipping"
+
+    client = redis.from_url(url)
+    patterns = list(_REDIS_LIGHTRAG_KEY_PATTERNS)
+
+    # Add patterns for any known workspaces. Read WORKSPACE from env plus
+    # any extras passed via --workspaces.
+    known = set()
+    env_ws = os.environ.get("WORKSPACE", "").strip()
+    if env_ws:
+        known.add(env_ws)
+    for ws in _extra_workspaces:
+        if ws:
+            known.add(ws)
+    for ws in sorted(known):
+        # LightRAG storage namespaces (see storage_namespace.py upstream)
+        for ns in (
+            "doc_status",
+            "full_docs",
+            "text_chunks",
+            "entity_chunks",
+            "relation_chunks",
+            "full_entities",
+            "full_relations",
+            "llm_response_cache",
+        ):
+            patterns.append(f"{ws}_{ns}:*")
+
+    if include_all_workspaces:
+        # Broad sweep: any key ending in a LightRAG namespace, regardless
+        # of the (unknown) workspace prefix. Suffixes are unique to
+        # LightRAG so collisions with backend keys are unlikely.
+        for ns in (
+            "doc_status",
+            "full_docs",
+            "text_chunks",
+            "entity_chunks",
+            "relation_chunks",
+            "full_entities",
+            "full_relations",
+        ):
+            patterns.append(f"*_{ns}:*")
+
+    if not execute:
+        sample = {}
+        for pat in patterns:
+            count = sum(1 for _ in _scan_keys(client, pat))
+            sample[pat] = count
+        total = sum(sample.values())
+        return f"would delete {total} Redis key(s) across {len(patterns)} pattern(s); {sample}"
+
+    deleted = 0
+    for pat in patterns:
+        batch = []
+        for key in _scan_keys(client, pat):
+            batch.append(key)
+            if len(batch) >= 500:
+                deleted += client.delete(*batch)
+                batch = []
+        if batch:
+            deleted += client.delete(*batch)
+    return f"Redis: deleted {deleted} key(s)"
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+_extra_workspaces: list[str] = []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually wipe. Default is dry-run, which only reports.",
+    )
+    parser.add_argument(
+        "--only",
+        choices=["postgres", "neo4j", "qdrant", "redis"],
+        action="append",
+        help="Limit to one backend. Repeatable. Default: all four.",
+    )
+    parser.add_argument(
+        "--workspaces",
+        nargs="*",
+        default=[],
+        help="Extra workspace names whose Redis keys should be deleted. "
+        "The value of $WORKSPACE is included automatically.",
+    )
+    parser.add_argument(
+        "--include-all-workspaces",
+        action="store_true",
+        help="Also delete Redis keys for any unknown workspace whose suffix matches "
+        "a LightRAG namespace. Use after multi-workspace deployments.",
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=Path(".env"),
+        help="Path to env file (default: ./.env)",
+    )
+    args = parser.parse_args()
+
+    load_env_file(args.env_file)
+
+    global _extra_workspaces
+    _extra_workspaces = list(args.workspaces)
+
+    backends = args.only or ["postgres", "neo4j", "qdrant", "redis"]
+
+    mode = "EXECUTE" if args.execute else "DRY RUN"
+    print(f"=== {mode} | backends: {', '.join(backends)} ===\n")
+
+    if not args.execute:
+        print("(no writes will happen — pass --execute to actually wipe)\n")
+
+    results = {}
+    started = time.time()
+
+    if "postgres" in backends:
+        print("[postgres] ", end="", flush=True)
+        try:
+            results["postgres"] = wipe_postgres(args.execute)
+        except Exception as e:
+            results["postgres"] = f"ERROR: {e}"
+        print(results["postgres"])
+
+    if "neo4j" in backends:
+        print("[neo4j]    ", end="", flush=True)
+        try:
+            results["neo4j"] = wipe_neo4j(args.execute)
+        except Exception as e:
+            results["neo4j"] = f"ERROR: {e}"
+        print(results["neo4j"])
+
+    if "qdrant" in backends:
+        print("[qdrant]   ", end="", flush=True)
+        try:
+            results["qdrant"] = wipe_qdrant(args.execute)
+        except Exception as e:
+            results["qdrant"] = f"ERROR: {e}"
+        print(results["qdrant"])
+
+    if "redis" in backends:
+        print("[redis]    ", end="", flush=True)
+        try:
+            results["redis"] = wipe_redis(args.execute, args.include_all_workspaces)
+        except Exception as e:
+            results["redis"] = f"ERROR: {e}"
+        print(results["redis"])
+
+    elapsed = time.time() - started
+    print(f"\ndone in {elapsed:.1f}s")
+    return 0 if all(not str(v).startswith("ERROR") for v in results.values()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two pieces of operational tooling for the per-request-workspace deploy, plus the WebUI work that lets users see workspaces other than the server default.

**3 commits:**
- `660ef1d7` — `scripts/wipe_storage.py` — wipes LightRAG storage (Postgres + Neo4j + Qdrant + selective Redis); paired with the reingest script in app-mod
- `9718cef6` — WebUI workspace selector + `GET /workspaces` endpoint + `/health` resilience fix
- (any subsequent commits as they land)

## Stacked on top of #13

Targets `feat/token-tracking-on-upstream`. **Retarget to `develop` once #10–#13 merge.**

---

## Part 1 — `scripts/wipe_storage.py`

Operational script for the per-request-workspace deploy. Wipes every LightRAG-managed datum across Postgres / Neo4j / Qdrant / Redis while explicitly preserving backend-owned Redis namespaces.

### What it does

- **Postgres**: drops and recreates the `lightrag` database. LightRAG re-creates the schema on its next startup.
- **Neo4j**: `MATCH (n) DETACH DELETE n` against the configured database.
- **Qdrant**: deletes every collection.
- **Redis**: surgical sweep of LightRAG-owned keys.

### Redis sweep details

**Always deleted:**
- Legacy unprefixed patterns (`entity_chunks:*`, `relation_chunks:*`, `full_entities:*`, `full_relations:*`, `text_chunks:*`, `full_docs:doc-*`) from before per-workspace prefixing
- Workspace-prefixed keys for `$WORKSPACE` and any names passed via `--workspaces`
- `--include-all-workspaces` mode additionally sweeps any key whose suffix matches a LightRAG namespace, useful after multi-workspace deploys

**Always preserved:**
- `ingestion:*` — backend ingestion tracking
- `schema:*` — backend schema cache
- `arq:*` — async task queue state
- `llm_response_cache:default:*` (unprefixed) — preserved out of caution since the name is ambiguous

### Safety

- **Default is dry-run.** `--execute` must be passed to actually wipe.
- `--only <backend>` to limit to one of `postgres`, `neo4j`, `qdrant`, `redis`. Useful for retrying after partial failure.
- Reads credentials from `./.env` (same file LightRAG itself uses).

### Tested locally (full cutover)

```
[postgres] dropped and recreated 'lightrag'
[neo4j]    Neo4j: deleted 721 nodes (was 721, now 0)
[qdrant]   Qdrant: dropped 3/3 collection(s)
[redis]    Redis: deleted 1854 key(s)
done in 1.3s
```

Then `docker restart lightrag` → reingest script (in app-mod) → 25/25 docs back, zero stuck rows.

---

## Part 2 — Workspace selector in the WebUI

Before this commit the WebUI sent requests without any `LIGHTRAG-WORKSPACE` header, so the server always fell through to `args.workspace`. Even though the data layer fully supports multi-workspace (via the per-request-workspace work in #12), users could only see whatever the env-configured workspace held. This makes the WebUI workspace-aware.

### What changed

**Server**
- New `GET /workspaces` endpoint (auth-gated). Returns `[{workspace, doc_count}, ...]` from a `DISTINCT workspace` query against `lightrag_doc_status` when PGDocStatusStorage is in use. Falls back to the registry's known workspaces for non-PG backends.
- `/health` no longer 500s when the requested workspace has no `pipeline_status` namespace yet. Catches the namespace lookup error and returns empty pipeline_status — `/health` is a probe, not a workspace initializer.

**WebUI**
- New `workspace` field in the settings store, persisted in localStorage.
- Axios interceptor injects `LIGHTRAG-WORKSPACE` on every request when settings has a non-empty workspace. Sits alongside the existing X-API-Key + Bearer-token handling.
- AppSettings popover gains a workspace dropdown populated from `/workspaces`, with `(server default)` and `Custom…` entries. Picking a value closes the popover so the user sees the view refresh.
- DocumentManager re-runs its refresh logic whenever workspace changes — so the table updates instantly on selection, no manual reload needed.

### Tested live

```
GET /workspaces →
  {"workspaces": [
    {"workspace": "platform_docs", "doc_count": 22},
    {"workspace": "solution_2550", "doc_count":  3},
    {"workspace": "solution_2551", "doc_count":  1}
  ]}
```

Switching the dropdown to `solution_2550` instantly refreshed the document table to show its 3 docs. Switching back to `(server default)` re-showed the 22 platform docs.

### Known limitation

The dropdown only knows about workspaces that **already have at least one indexed doc**. To upload to a new workspace, pick `Custom…` and type the name first, then upload. After the upload completes, that workspace becomes part of the dropdown list on the next popover open.

---

## Reviewer notes

- Two unrelated concerns in one PR — flagged because they share the deploy story (the WebUI selector becomes useful once the per-request workspace work is deployed, and the wipe script is part of that deploy procedure).
- If you'd rather split: the WebUI changes touch `lightrag_webui/src/**` + a single endpoint in `lightrag_server.py`, easy to cherry-pick out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)