### PR TITLE
fix(api): make DocumentManager per-workspace so uploads land in the right dir

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -218,6 +218,37 @@ class WorkspaceRegistry:
         self._instances.clear()
 
 
+class DocumentManagerRegistry:
+    """Lazy registry of DocumentManager instances keyed by workspace.
+
+    Uploads land in a workspace-scoped subdirectory of args.input_dir so
+    that on-disk files don't get mixed across workspaces. Without this,
+    a `/documents/upload` request with `LIGHTRAG-WORKSPACE: solution_42`
+    would still drop the file in the server-default workspace's
+    subdirectory (the singleton DocumentManager bug).
+
+    Construction is synchronous — DocumentManager.__init__ just calls
+    Path.mkdir — so no async lock is needed; a plain dict suffices.
+    """
+
+    def __init__(self, input_dir: str, default_workspace: Optional[str] = None):
+        self._input_dir = input_dir
+        self._default_workspace = default_workspace or ""
+        self._instances: dict[str, "DocumentManager"] = {}
+
+    def _normalize(self, workspace):
+        return workspace if workspace else self._default_workspace
+
+    def get(self, workspace):
+        key = self._normalize(workspace)
+        cached = self._instances.get(key)
+        if cached is not None:
+            return cached
+        manager = DocumentManager(self._input_dir, workspace=key or "")
+        self._instances[key] = manager
+        return manager
+
+
 def check_frontend_build():
     """Check if frontend is built and optionally check if source is up-to-date
 
@@ -407,8 +438,14 @@ def create_app(args):
     # Check if API key is provided either through env var or args
     api_key = os.getenv("LIGHTRAG_API_KEY") or args.key
 
-    # Initialize document manager with workspace support for data isolation
-    doc_manager = DocumentManager(args.input_dir, workspace=args.workspace)
+    # Initialize a per-workspace DocumentManager registry so uploads land in
+    # the right workspace subdirectory of args.input_dir. Pre-create the
+    # server-default workspace's manager so the directory exists at startup
+    # (matches the pre-registry behavior).
+    doc_manager_registry = DocumentManagerRegistry(
+        input_dir=args.input_dir, default_workspace=args.workspace
+    )
+    doc_manager_registry.get(args.workspace)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -1290,6 +1327,12 @@ def create_app(args):
         workspace = get_workspace_from_request(request)
         return await workspace_registry.get(workspace)
 
+    def get_doc_manager(request: Request) -> "DocumentManager":
+        """Resolve the DocumentManager for this request's workspace so on-disk
+        uploads/archives land in the right subdirectory."""
+        workspace = get_workspace_from_request(request)
+        return doc_manager_registry.get(workspace)
+
     # Add routes
     # root_path is set on the app for reverse proxy support;
     # routes stay at their natural paths and are prefixed by the proxy or uvicorn --root-path
@@ -1297,7 +1340,7 @@ def create_app(args):
     # /query, /documents, and /graph all resolve the LightRAG instance per
     # request via the LIGHTRAG-WORKSPACE header. The Ollama compatibility
     # surface still binds to the default workspace.
-    app.include_router(create_document_routes(get_rag, doc_manager, api_key))
+    app.include_router(create_document_routes(get_rag, get_doc_manager, api_key))
     app.include_router(create_query_routes(get_rag, api_key, args.top_k))
     app.include_router(create_graph_routes(get_rag, api_key))
 

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2112,8 +2112,18 @@ async def background_delete_documents(
 
 
 def create_document_routes(
-    get_rag, doc_manager: DocumentManager, api_key: Optional[str] = None
+    get_rag, get_doc_manager, api_key: Optional[str] = None
 ):
+    """Build the /documents router.
+
+    Args:
+        get_rag: callable(request) -> awaitable LightRAG. Resolves the
+            LightRAG instance for the request's workspace.
+        get_doc_manager: callable(request) -> DocumentManager. Resolves the
+            DocumentManager for the request's workspace so uploads/archives
+            land in the right per-workspace subdirectory of the input dir.
+        api_key: optional API key for combined-auth gating.
+    """
     # Fresh router per call — see the note above the temp_prefix constant.
     router = APIRouter(
         prefix="/documents",
@@ -2127,12 +2137,17 @@ def create_document_routes(
         """Resolve the LightRAG instance for this request's workspace."""
         return await get_rag(request)
 
+    def _dm_dep(request: Request) -> DocumentManager:
+        """Resolve the per-workspace DocumentManager for this request."""
+        return get_doc_manager(request)
+
     @router.post(
         "/scan", response_model=ScanResponse, dependencies=[Depends(combined_auth)]
     )
     async def scan_for_new_documents(
         background_tasks: BackgroundTasks,
         rag: LightRAG = Depends(_rag_dep),
+        doc_manager: DocumentManager = Depends(_dm_dep),
     ):
         """
         Trigger the scanning process for new documents.
@@ -2162,6 +2177,7 @@ def create_document_routes(
         background_tasks: BackgroundTasks,
         file: UploadFile = File(...),
         rag: LightRAG = Depends(_rag_dep),
+        doc_manager: DocumentManager = Depends(_dm_dep),
     ):
         """
         Upload a file to the input directory and index it.
@@ -2493,7 +2509,10 @@ def create_document_routes(
     @router.delete(
         "", response_model=ClearDocumentsResponse, dependencies=[Depends(combined_auth)]
     )
-    async def clear_documents(rag: LightRAG = Depends(_rag_dep)):
+    async def clear_documents(
+        rag: LightRAG = Depends(_rag_dep),
+        doc_manager: DocumentManager = Depends(_dm_dep),
+    ):
         """
         Clear all documents from the RAG system.
 
@@ -2911,6 +2930,7 @@ def create_document_routes(
         delete_request: DeleteDocRequest,
         background_tasks: BackgroundTasks,
         rag: LightRAG = Depends(_rag_dep),
+        doc_manager: DocumentManager = Depends(_dm_dep),
     ) -> DeleteDocByIdResponse:
         """
         Delete documents and all their associated data by their IDs using background processing.


### PR DESCRIPTION
## Summary

- After the workspace migration, `/documents/upload` correctly routed LightRAG storage (Postgres/Neo4j/Qdrant/Redis) to the request's workspace, **but the on-disk file landed in the wrong workspace's subdirectory** of `args.input_dir` because a single `DocumentManager` was bound at startup with the server-default workspace.
- This PR introduces a `DocumentManagerRegistry` (mirroring `WorkspaceRegistry`) and injects the per-request `DocumentManager` via FastAPI `Depends`, so uploads/archives/deletes use the workspace from the `LIGHTRAG-WORKSPACE` header.

## What broke before this PR

Reproducible on the lab: every solution-scope upload (e.g. `LIGHTRAG-WORKSPACE: solution_2550`) had its raw file written to `inputs/platform_docs/<file>` and archived to `inputs/platform_docs/__enqueued__/`, instead of `inputs/solution_2550/__enqueued__/`. Backend confirmed: no `solution_2550/` or `solution_2551/` subdir ever existed on disk despite uploads succeeding.

Concrete consequences:
- Solution files archived under the platform workspace's subdir — confusing for any disk-side audit.
- Filename collision risk across workspaces sharing the same subdir.
- Delete (`/documents/delete_document` with `delete_file=true`) searched the default workspace's dir, missing the actual file.
- `/documents/scan` background sweeps targeted the wrong workspace.

LightRAG-side data (Postgres/Neo4j/Qdrant/Redis) was unaffected — those layers already respect the workspace header. Only the on-disk file location was wrong.

## What this PR does

`lightrag/api/lightrag_server.py`:
- Adds `DocumentManagerRegistry` — lazy, per-workspace `DocumentManager` construction.
- Replaces the singleton `doc_manager = DocumentManager(args.input_dir, workspace=args.workspace)` with the registry.
- Pre-creates the server-default workspace's manager at startup so `inputs/<default>/` exists immediately.
- Passes `get_doc_manager(request)` into `create_document_routes()` instead of the singleton.

`lightrag/api/routers/document_routes.py`:
- Updates `create_document_routes(get_rag, get_doc_manager, api_key)` signature.
- Adds `_dm_dep(request) -> DocumentManager` resolver alongside `_rag_dep`.
- Injects `doc_manager: DocumentManager = Depends(_dm_dep)` into the four handlers that touched it:
  - `/documents/scan`
  - `/documents/upload`
  - `/documents` (DELETE — clear)
  - `/documents/delete_document`

Other routers (`query_routes.py`, `graph_routes.py`) were already `Depends`-based and untouched.

## Out of scope (intentional)

- **Ollama compatibility surface** (`lightrag/api/routers/ollama_api.py`) still binds to the default workspace via `OllamaAPI(rag, ...)`. Same shape of bug, separate PR — flagged for follow-up. Doesn't affect the backend or WebUI, which use `/query` not `/api/chat`.
- **Existing on-disk orphans** under `inputs/platform_docs/__enqueued__/` that actually belong to other workspaces remain in place. They're functional dead weight (LightRAG never scans them post-fix) and can be moved/cleaned manually if needed.

## Test plan

- [ ] Restart LightRAG with this build
- [ ] Upload one doc via `POST /documents/upload` with `LIGHTRAG-WORKSPACE: solution_2550` and confirm the raw file appears in `inputs/solution_2550/<file>` (not in `inputs/platform_docs/`)
- [ ] After processing, confirm the file is archived to `inputs/solution_2550/__enqueued__/`
- [ ] Delete that doc with `LIGHTRAG-WORKSPACE: solution_2550` and `delete_file=true`, confirm the archived file is removed from `inputs/solution_2550/__enqueued__/`
- [ ] Repeat with `platform_docs` workspace — confirm uploads still land in `inputs/platform_docs/` (no regression)
- [ ] `/documents/scan` with `LIGHTRAG-WORKSPACE: solution_2550` triggers a scan of `inputs/solution_2550/` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)