### PR TITLE
fix(tracker): use contextvars for per-doc/per-query token attribution

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -99,6 +99,8 @@ from lightrag.utils import (
     TiktokenTokenizer,
     EmbeddingFunc,
     TokenTracker,
+    current_llm_tracker,
+    current_embedding_tracker,
     always_get_an_event_loop,
     compute_mdhash_id,
     lazy_external_import,
@@ -1901,32 +1903,23 @@ class LightRAG:
                     # embedding usage spent indexing this one document so the
                     # cost can be attributed downstream.
                     #
-                    # IMPORTANT: we wrap llm_model_func with a *closure*, not
-                    # functools.partial. extract_entities reads the func via
-                    # `global_config = asdict(self)`, and `asdict` deep-copies
-                    # non-dataclass values — which would clone the partial's
-                    # `keywords` dict (including the TokenTracker), sending the
-                    # actual usage updates into a clone instead of our tracker.
-                    # Closures are deepcopy-immortal in Python, so the
-                    # `doc_llm_tracker` reference inside the closure survives.
-                    #
-                    # CAVEAT: with max_parallel_insert > 1, multiple docs share
-                    # these mutable hooks — recorded per-doc usage is
-                    # approximate (totals are correct, per-doc attribution is
-                    # fuzzy). Set MAX_PARALLEL_INSERT=1 for exact accounting.
+                    # Trackers are bound to per-async-task contextvars
+                    # (see lightrag.utils.current_llm_tracker /
+                    # current_embedding_tracker). asyncio.create_task() copies
+                    # the current context when each doc task is created, so
+                    # two parallel docs each get their own value — no shared
+                    # mutation of `self.llm_model_func` or
+                    # `embedding_inner.token_tracker` is required, and the
+                    # MAX_PARALLEL_INSERT > 1 race that used to corrupt
+                    # per-doc attribution is gone.
                     doc_llm_tracker = TokenTracker()
                     doc_embedding_tracker = TokenTracker()
-                    original_llm_model_func = self.llm_model_func
+                    current_llm_tracker.set(doc_llm_tracker)
+                    current_embedding_tracker.set(doc_embedding_tracker)
 
-                    async def _llm_with_tracker(*args, **kwargs):
-                        kwargs.setdefault("token_tracker", doc_llm_tracker)
-                        return await original_llm_model_func(*args, **kwargs)
-
-                    self.llm_model_func = _llm_with_tracker
                     embedding_inner = getattr(
                         self.embedding_func, "__wrapped__", self.embedding_func
                     )
-                    embedding_inner.token_tracker = doc_embedding_tracker
 
                     def _doc_token_usage_metadata() -> dict[str, Any]:
                         return {
@@ -2303,14 +2296,12 @@ class LightRAG:
                                     }
                                 )
 
-                    # Restore the original llm_model_func and clear the embedding
-                    # tracker now that this document is done. Done at the end of
-                    # process_document so the trackers don't leak across docs.
-                    # (The inner try/except blocks handle all expected failures,
-                    # so this point is reached on both success and handled
-                    # failure paths.)
-                    self.llm_model_func = original_llm_model_func
-                    embedding_inner.token_tracker = None
+                    # No teardown needed: the per-doc trackers live in
+                    # asyncio-task-scoped contextvars (see lightrag.utils),
+                    # which evaporate when this task's coroutine returns.
+                    # Neither self.llm_model_func nor
+                    # embedding_inner.token_tracker were mutated, so there's
+                    # nothing to restore.
 
                 # Create processing tasks for all documents
                 doc_tasks = []
@@ -2981,7 +2972,11 @@ class LightRAG:
             param = replace(param, model_func=partial(param.model_func, token_tracker=llm_tracker))
 
         embedding_inner = getattr(self.embedding_func, "__wrapped__", self.embedding_func)
-        embedding_inner.token_tracker = embedding_tracker
+        # Bind the per-request embedding tracker to the contextvar instead of
+        # mutating the shared EmbeddingFunc wrapper. Concurrent queries each
+        # get their own snapshot because asyncio tasks copy the context on
+        # creation, so parallel calls don't clobber each other.
+        current_embedding_tracker.set(embedding_tracker)
 
         def _build_token_usage_block() -> dict[str, Any]:
             return {
@@ -3110,9 +3105,11 @@ class LightRAG:
                 **_build_token_usage_block(),
             }
         finally:
-            # Detach the embedding tracker so future requests don't accidentally
-            # share usage state through the shared EmbeddingFunc wrapper.
-            embedding_inner.token_tracker = None
+            # No teardown needed: the per-request embedding tracker is held
+            # by the current_embedding_tracker contextvar and evaporates with
+            # this task's context. The shared EmbeddingFunc wrapper is never
+            # mutated by this call site.
+            pass
 
     def query_llm(
         self,

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4,6 +4,7 @@ import weakref
 import sys
 
 import asyncio
+import contextvars
 import html
 import csv
 import inspect
@@ -537,9 +538,15 @@ class EmbeddingFunc:
                 kwargs["max_token_size"] = self.max_token_size
 
         # Pass token_tracker through so the underlying provider records usage.
-        # Caller-supplied trackers take precedence over the wrapper-level one.
-        if self.token_tracker is not None and "token_tracker" not in kwargs:
-            kwargs["token_tracker"] = self.token_tracker
+        # Resolution order: kwargs (caller-supplied) > current_embedding_tracker
+        # contextvar (per-doc, set by process_document) > self.token_tracker
+        # (instance-level legacy fallback).
+        if "token_tracker" not in kwargs:
+            ctx_tracker = current_embedding_tracker.get(None)
+            if ctx_tracker is not None:
+                kwargs["token_tracker"] = ctx_tracker
+            elif self.token_tracker is not None:
+                kwargs["token_tracker"] = self.token_tracker
 
         # Call the actual embedding function
         result = await self.func(*args, **kwargs)
@@ -2081,6 +2088,13 @@ async def use_llm_func_with_cache(
             - For cache hits: (content, cache_create_time)
             - For cache misses: (content, current_timestamp)
     """
+    # If the caller didn't pass an explicit token_tracker, fall back to the
+    # per-async-task contextvar set by process_document(). This is what
+    # makes per-doc LLM-usage attribution work under MAX_PARALLEL_INSERT > 1
+    # without anyone having to thread the tracker through the call site.
+    if token_tracker is None:
+        token_tracker = current_llm_tracker.get(None)
+
     # Sanitize input text to prevent UTF-8 encoding errors for all LLM providers
     safe_user_prompt = sanitize_text_for_encoding(user_prompt)
     safe_system_prompt = (
@@ -2625,6 +2639,24 @@ async def pick_by_vector_similarity(
         # Fallback to simple truncation
         logger.debug("[VECTOR_SIMILARITY] Falling back to simple truncation")
         return all_chunk_ids[:num_of_chunks]
+
+
+# Per-async-task token-tracker contextvars. process_document() binds these
+# to a per-doc TokenTracker via .set() at the start of each doc; downstream
+# LLM (use_llm_func_with_cache) and embedding (EmbeddingFunc.__call__)
+# callers fall back to these when no explicit tracker is passed.
+#
+# asyncio.create_task() snapshots the current context, so two docs running
+# in parallel each get their own copy — no shared mutation, no race. This
+# replaces the prior pattern of mutating `self.llm_model_func` and
+# `embedding_inner.token_tracker` at the LightRAG instance level, which
+# could not survive MAX_PARALLEL_INSERT > 1.
+current_llm_tracker: contextvars.ContextVar["TokenTracker | None"] = (
+    contextvars.ContextVar("current_llm_tracker", default=None)
+)
+current_embedding_tracker: contextvars.ContextVar["TokenTracker | None"] = (
+    contextvars.ContextVar("current_embedding_tracker", default=None)
+)
 
 
 class TokenTracker:


### PR DESCRIPTION
## Summary

- Per-doc token attribution was broken under `MAX_PARALLEL_INSERT > 1`: one "winner" doc per parallel cohort captured all the tokens, every other doc reported zero. Totals were correct but per-doc breakdown was unusable.
- This PR replaces the racy `self.llm_model_func` / `embedding_inner.token_tracker` mutations with asyncio-task-scoped `contextvars`, so each parallel doc task gets its own tracker snapshot.

## The race we're fixing

`process_document()` used to mutate the LightRAG instance to install per-doc trackers:

```python
self.llm_model_func = _llm_with_tracker          # mutates instance attr
embedding_inner.token_tracker = doc_embedding_tracker  # mutates shared EmbeddingFunc
```

With `MAX_PARALLEL_INSERT=2`, the timeline is:

| Doc A | Doc B |
|---|---|
| `self.llm_model_func = wrap_A` ||
| (stage 1: chunks_vdb, text_chunks) | `self.llm_model_func = wrap_B` ← overwrites A |
| `asdict(self)` captures **wrap_B** | `asdict(self)` captures wrap_B |
| LLM calls credit `doc_B_tracker` | LLM calls credit `doc_B_tracker` |
| metadata reads `doc_A_tracker` → **0** | metadata reads `doc_B_tracker` → both docs' tokens |

The code already acknowledged this in a comment ("with max_parallel_insert > 1, per-doc attribution is fuzzy. Set MAX_PARALLEL_INSERT=1 for exact accounting"). The "exact accounting" workaround halves indexing throughput.

## What this PR does

`lightrag/utils.py`:
- Adds `current_llm_tracker` and `current_embedding_tracker` `ContextVar`s.
- `EmbeddingFunc.__call__` falls back to `current_embedding_tracker` when the caller doesn't pass `token_tracker` (preserves backward-compat with the instance-level `self.token_tracker` as a last resort).
- `use_llm_func_with_cache` falls back to `current_llm_tracker` when `token_tracker=None`.

`lightrag/lightrag.py process_document`:
- Replaces `self.llm_model_func = _llm_with_tracker` and `embedding_inner.token_tracker = …` with `current_llm_tracker.set(doc_llm_tracker)` and `current_embedding_tracker.set(doc_embedding_tracker)`.
- Removes the end-of-function teardown. The contextvar value evaporates with the task's coroutine — no leak.

`lightrag/lightrag.py aquery_llm`:
- Same treatment for the per-request embedding tracker. (The LLM tracker was already non-racy via `partial()` into a per-call `global_config` dict.)
- Drops the `embedding_inner.token_tracker = None` cleanup in `finally:`.

## Why contextvars

`asyncio.create_task()` copies the current context when the task is created. Each parallel doc task gets its own snapshot of the contextvar, so two `process_document` coroutines running concurrently see their own trackers — no shared mutation. Embedding/LLM call sites that the task spawns (via `asyncio.gather` etc.) inherit the parent task's context automatically. Exactly the semantics we want.

## Test plan

- [ ] Rebuild lightrag image, wipe storage, run a full reingest of 25 docs (22 platform + 2 solution_2550 + 1 solution_2551) with `MAX_PARALLEL_INSERT=2`.
- [ ] Confirm every processed doc has non-zero `llm_token_usage.total_tokens` and `embedding_token_usage.total_tokens` in its `/documents` metadata.
- [ ] Confirm totals across all docs roughly match a previous `MAX_PARALLEL_INSERT=1` baseline (i.e., we didn't lose any tokens to the void).
- [ ] Run two concurrent queries against `/query` and confirm each response's `token_usage` block reflects only that request's calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)