### PR TITLE
fix(wipe): unconditionally sweep all workspace LLM caches

### DIFF
--- a/scripts/wipe_storage.py
+++ b/scripts/wipe_storage.py
@@ -16,11 +16,14 @@ WHAT THIS SCRIPT PRESERVES IN REDIS
       - `ingestion:*`     application ingestion tracking
       - `schema:*`        application schema cache
       - `arq:*`           async task queue state
-    The backend does not use the `llm_response_cache:*` namespace (grep
-    confirms), and post-workspace-migration LightRAG only ever writes to
-    `<workspace>_llm_response_cache:*` — so any unprefixed
-    `llm_response_cache:*` keys are pre-migration orphans and are deleted
-    along with the workspace-prefixed copies.
+
+EVERY OTHER LIGHTRAG-OWNED KEY IS DELETED
+    LightRAG's Redis namespaces (`doc_status`, `full_docs`, `text_chunks`,
+    `entity_chunks`, `relation_chunks`, `full_entities`, `full_relations`,
+    `llm_response_cache`) are swept under a wildcard prefix
+    (`*_<namespace>:*`), so per-request workspaces like `solution_42` that
+    the script can't enumerate statically still get cleaned. Pre-workspace
+    unprefixed copies (`llm_response_cache:*` etc.) are also deleted.
 
 USAGE
     # Dry run (default — prints what would change, no writes)
@@ -189,11 +192,19 @@ def _scan_keys(redis_client, pattern: str) -> Iterable[str]:
 def wipe_redis(execute: bool, include_all_workspaces: bool) -> str:
     """Delete LightRAG-owned keys, preserving backend state.
 
-    Two sweep modes:
-        - surgical (default): only fixed legacy patterns + the workspace
-          patterns enumerated below
-        - --include-all-workspaces: also matches any key whose suffix is one
-          of LightRAG's known namespaces (handles unknown workspaces)
+    Sweep strategy: every LightRAG-owned Redis key matches one of three
+    pattern groups, all swept unconditionally:
+      1. Fixed legacy unprefixed patterns (pre-workspace LightRAG data).
+      2. Per-workspace patterns for every workspace listed via env
+         (WORKSPACE) + --workspaces. Redundant with (3), kept for clarity.
+      3. Wildcard-prefix patterns (`*_<lightrag_namespace>:*`) catching
+         every workspace the script doesn't know about by name. This is
+         needed under PR #16's per-request workspaces, where
+         solution_<id> instances are created on demand and never appear
+         in any env var.
+
+    --include-all-workspaces used to gate (3); it's now a no-op (kept for
+    backward compatibility with existing automation).
     """
     import redis  # type: ignore
 
@@ -227,20 +238,34 @@ def wipe_redis(execute: bool, include_all_workspaces: bool) -> str:
         ):
             patterns.append(f"{ws}_{ns}:*")
 
-    if include_all_workspaces:
-        # Broad sweep: any key ending in a LightRAG namespace, regardless
-        # of the (unknown) workspace prefix. Suffixes are unique to
-        # LightRAG so collisions with backend keys are unlikely.
-        for ns in (
-            "doc_status",
-            "full_docs",
-            "text_chunks",
-            "entity_chunks",
-            "relation_chunks",
-            "full_entities",
-            "full_relations",
-        ):
-            patterns.append(f"*_{ns}:*")
+    # Always sweep every workspace's LightRAG-owned Redis namespaces by
+    # wildcard prefix. Per-request workspaces (PR #16) mean we cannot
+    # enumerate them statically — solution_<id> workspaces are created on
+    # demand by /documents/upload, so the WORKSPACE env var + --workspaces
+    # flag alone will never know about them all. These suffixes are unique
+    # to LightRAG (the backend reserves prefixes like `ingestion:`,
+    # `schema:`, `arq:`), so the wildcard match is safe.
+    #
+    # `llm_response_cache` was previously missing from this list, which
+    # caused solution_<id> LLM caches to survive every wipe and hand out
+    # stale cache hits during reingest — silently zeroing per-doc token
+    # tracking for any non-default workspace. It's included here so a fresh
+    # wipe truly starts from zero.
+    for ns in (
+        "doc_status",
+        "full_docs",
+        "text_chunks",
+        "entity_chunks",
+        "relation_chunks",
+        "full_entities",
+        "full_relations",
+        "llm_response_cache",
+    ):
+        patterns.append(f"*_{ns}:*")
+
+    # The --include-all-workspaces flag is now a no-op — the broad sweep is
+    # unconditional. Kept for backward compatibility with existing scripts.
+    del include_all_workspaces
 
     if not execute:
         sample = {}
@@ -292,8 +317,8 @@ def main() -> int:
     parser.add_argument(
         "--include-all-workspaces",
         action="store_true",
-        help="Also delete Redis keys for any unknown workspace whose suffix matches "
-        "a LightRAG namespace. Use after multi-workspace deployments.",
+        help="Deprecated no-op; the broad cross-workspace sweep is now "
+        "always on (required for per-request workspaces).",
     )
     parser.add_argument(
         "--env-file",


### PR DESCRIPTION
## Summary

- `wipe_storage.py` skipped `llm_response_cache` for unknown workspaces, leaving stale LLM caches behind every wipe.
- A reingest after the wipe would HIT those stale entries via cache instead of calling the LLM, which silently zeroed per-doc token tracking for affected workspaces.
- This PR makes the cross-workspace sweep `*_<namespace>:*` unconditional and includes `llm_response_cache` in it.

## How the bug showed up

In a recent reingest test with PR #17's contextvars fix active:
- **platform_docs**: 22/22 docs had non-zero LLM tokens ✓
- **solution_2550**: 2/2 docs had `llm_tokens=0` despite the LLM having clearly been called
- **solution_2551**: 1/1 doc had `llm_tokens=0`

Looked like the contextvars fix wasn't working — but Redis OBJECT IDLETIME on the `solution_2550_llm_response_cache:*` keys was **26,404s (~7.3 h)**, while the wipe had run minutes earlier. Those keys were left over from an earlier run; the reingest hit them as cache, and cache hits never invoke the LLM provider, so the tracker correctly stayed at zero.

Root cause in the wipe script: the broad-sweep namespace list (gated behind `--include-all-workspaces`) included `doc_status`, `full_docs`, `text_chunks`, `entity_chunks`, `relation_chunks`, `full_entities`, `full_relations` — but **not** `llm_response_cache`. Under per-request workspaces (PR #16), solution_<id> workspaces are created on demand by `/documents/upload` and never appear in any env var, so the per-known-workspace pattern list missed them too.

## What this PR does

`scripts/wipe_storage.py`:
- Move the wildcard-prefix sweep out from under `--include-all-workspaces`. It now runs every time. Per-request workspaces mean we can't enumerate them statically, so the broad sweep has to be the default.
- Add `llm_response_cache` to the swept namespaces.
- `--include-all-workspaces` becomes a deprecated no-op, kept so existing CI/automation that passes it doesn't break.
- Top-of-file docstring updated to match. Help text on the flag updated to say "Deprecated no-op".

## Why this is safe

The backend reserves its own Redis namespaces (`ingestion:*`, `schema:*`, `arq:*`) — confirmed via grep. The eight LightRAG namespaces being swept (`doc_status`, `full_docs`, `text_chunks`, `entity_chunks`, `relation_chunks`, `full_entities`, `full_relations`, `llm_response_cache`) are LightRAG-only suffixes; nothing else in the stack uses them. So `*_<ns>:*` cannot collide with backend keys.

## Test plan

- [ ] Dry-run shows wildcard patterns with non-zero counts for unknown workspaces:
  ```
  *_llm_response_cache:*: <N>  ← should match solution_<id> caches
  ```
- [ ] Run `python scripts/wipe_storage.py --execute`, then a reingest of 3 workspaces' worth of docs.
- [ ] Confirm every processed doc in every workspace has non-zero `llm_token_usage.total_tokens` in metadata (no stale cache hits).
- [ ] Confirm backend namespaces survive: `ingestion:*`, `schema:*`, `arq:*` key counts unchanged after wipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)