### PR TITLE
fix(streaming): emit accurate LLM token usage when streaming

### DIFF
--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -784,11 +784,6 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
                         enriched_references.append(ref_copy)
                     references = enriched_references
 
-                token_usage = _build_token_usage_response(result)
-                token_usage_dump = (
-                    token_usage.model_dump(exclude_none=True) if token_usage else None
-                )
-
                 if llm_response.get("is_streaming"):
                     # Streaming mode: send references first, then stream response chunks
                     if request.include_references:
@@ -804,15 +799,40 @@ def create_query_routes(get_rag, api_key: Optional[str] = None, top_k: int = 60)
                             logger.error(f"Streaming error: {str(e)}")
                             yield f"{json.dumps({'error': str(e)})}\n"
 
+                    # Re-snapshot token usage AFTER the stream completes.
+                    # Streaming LLM providers only call ``llm_tracker.add(...)``
+                    # once the stream ends, so the pre-stream snapshot in
+                    # ``result`` carries only the embedding call. The
+                    # ``_refresh_token_usage`` callable was attached by
+                    # ``aquery_llm`` exactly for this purpose; it re-reads
+                    # the same trackers and now sees the LLM call_count
+                    # populated.
+                    refresh_token_usage = result.get("_refresh_token_usage")
+                    if callable(refresh_token_usage):
+                        result.update(refresh_token_usage())
+                    token_usage = _build_token_usage_response(result)
+                    token_usage_dump = (
+                        token_usage.model_dump(exclude_none=True) if token_usage else None
+                    )
+
                     # Emit token usage as the final NDJSON frame so streaming
                     # clients can record cost without re-querying.
                     if token_usage_dump is not None:
                         yield f"{json.dumps({'token_usage': token_usage_dump})}\n"
                 else:
-                    # Non-streaming mode: send complete response in one message
+                    # Non-streaming mode: send complete response in one message.
+                    # The LLM call has already completed by the time aquery_llm
+                    # returned, so the snapshot in ``result`` already reflects
+                    # the full LLM usage and we can build the response model
+                    # directly.
                     response_content = llm_response.get("content", "")
                     if not response_content:
                         response_content = "No relevant context found for the query."
+
+                    token_usage = _build_token_usage_response(result)
+                    token_usage_dump = (
+                        token_usage.model_dump(exclude_none=True) if token_usage else None
+                    )
 
                     # Create complete response object
                     complete_response = {"response": response_content}

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3086,6 +3086,13 @@ class LightRAG:
                 "is_streaming": query_result.is_streaming,
             }
             raw_data.update(_build_token_usage_block())
+            # Stream consumers should call this AFTER they finish iterating
+            # ``response_iterator``. Streaming LLM providers only call
+            # ``llm_tracker.add(...)`` when the stream completes, so the
+            # snapshot above carries only embedding usage (recorded during
+            # retrieval). Re-snapshotting after the stream picks up the LLM
+            # call_count + prompt/completion tokens that arrive later.
+            raw_data["_refresh_token_usage"] = _build_token_usage_block
 
             return raw_data
 

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -332,6 +332,19 @@ async def openai_complete_if_cache(
     if timeout is not None:
         kwargs["timeout"] = timeout
 
+    # Ask OpenAI/Azure to include token usage in the final streaming chunk.
+    # Without ``stream_options={"include_usage": True}`` no chunk carries a
+    # ``usage`` attribute, so ``token_tracker.add_usage`` further down never
+    # fires and every streaming query reports zero LLM tokens. Preserve a
+    # caller-supplied ``stream_options`` if one is passed — merge rather
+    # than overwrite so callers can layer additional flags later.
+    if kwargs.get("stream"):
+        existing = kwargs.get("stream_options") or {}
+        if not isinstance(existing, dict):
+            existing = {}
+        existing.setdefault("include_usage", True)
+        kwargs["stream_options"] = existing
+
     # Determine the correct model identifier to use
     # For Azure OpenAI, we must use the deployment name instead of the model name
     api_model = azure_deployment if use_azure and azure_deployment else model


### PR DESCRIPTION
Streaming queries against /query/stream returned token_usage with the LLM block missing — embedding was reported but the LLM call_count came back as zero, so downstream cost loggers saw nothing for the actual answer. Three changes together restore the LLM tokens:

- `lightrag/llm/openai.py`: when calling `chat.completions.create` with `stream=True`, inject `stream_options={"include_usage": True}` so OpenAI/Azure includes the usage block in the final streaming chunk. Without this no chunk ever carried `.usage`, `final_chunk_usage` stayed None, and `token_tracker.add_usage(...)` was never called.
- `lightrag/lightrag.py`: `aquery_llm` now attaches the `_build_token_usage_block` closure to its result dict as `_refresh_token_usage`. The pre-stream snapshot in the result only captures embedding usage (recorded during retrieval) — streaming consumers need to re-snapshot after they finish iterating the response so the LLM usage that arrives at the end is picked up.
- `lightrag/api/routers/query_routes.py`: the streaming branch in `query_text_stream` now calls `_refresh_token_usage` after the response loop completes, then rebuilds the `TokenUsageResponse` so the final NDJSON frame carries the populated `llm` block. The non-streaming branch was already correct (the snapshot is taken after the LLM call returns) and is left unchanged.

Verified end-to-end: a streaming query now reports `llm.prompt_tokens > 0` and `llm.completion_tokens > 0` in the final `{"token_usage": ...}` frame, identical in shape to what /query returns in non-streaming mode.